### PR TITLE
Sharing Maps UX Makes More Sense

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -184,6 +184,11 @@ class Nav extends Component {
                                 analytics.event(analytics._event.SIDE_NAV + ' Share', 'Clicked');
                                 analytics.pageview('/app/my-maps/share');
                                 this.props.dispatch({ type: 'OPEN_MODAL', payload: "share" })
+                                if (this.props.currentMapId)
+                                    this.props.dispatch({
+                                        type: 'SET_MAP_TO_SHARE',
+                                        payload: this.props.maps.filter(map => map.map.eid == this.props.currentMapId)[0]
+                                    })
                             }
                         }}
                     />
@@ -228,7 +233,7 @@ Nav.propTypes = {
     active: PropTypes.string
 };
 
-const mapStateToProps = ({ navigation, information, informationSections, readOnly, drawings, markers, mapMeta, user }) => ({
+const mapStateToProps = ({ navigation, information, informationSections, readOnly, drawings, markers, mapMeta, user, myMaps }) => ({
     open: navigation.open,
     active: navigation.active,
     information,
@@ -239,6 +244,7 @@ const mapStateToProps = ({ navigation, information, informationSections, readOnl
     activePolygon: drawings.activePolygon,
     currentMapId: mapMeta.currentMapId,
     user: user,
+    maps: myMaps.maps,
 });
 
 export default connect(mapStateToProps, null)(Nav);

--- a/src/components/modals/Share/EmailShare.js
+++ b/src/components/modals/Share/EmailShare.js
@@ -9,41 +9,37 @@ class EmailShare extends Component {
         super(props);
         this.state = {
             input: '',
+            emails: []
         }
     }
 
     removeEmail = (i) => {
-        this.props.dispatch({
-            type: 'REMOVE_SHARE_EMAIL',
-            payload: i
-        })
+        const emails = this.state.emails.slice();
+        this.setState({ emails: emails.splice(i, 1) });
     }
 
     addEmail = () => {
         if (emailRegexp.test(this.state.input)) {
-            this.props.dispatch({
-                type: 'ADD_SHARE_EMAIL',
-                payload: this.state.input
-            });
-            this.setState({ input: '' })
+            const emails = this.state.emails.slice();
+            emails.push(this.state.input);
+            this.setState({ input: '', emails: emails });
         }
     }
 
     closeModal = () => {
         this.props.dispatch({ type: 'CLOSE_MODAL', payload: 'share' });
-        this.props.dispatch({ type: 'CLEAR_MAP_TO_SHARE' });
+        this.setState({ input: '', emails: [] });
     }
 
     share(id) {
-        let dt = {
+        const { emails } = this.props;
+        if (emails.length == 0)
+            return;
+        const shareData = {
             "eid": id,
-            "emailAddresses": this.props.emails
+            "emailAddresses": emails
         };
-        console.log(dt);
-        axios.post(`${constants.ROOT_URL}/api/user/map/share/sync/`, {
-            "eid": id,
-            "emailAddresses": this.props.emails
-        }, getAuthHeader())
+        axios.post(`${constants.ROOT_URL}/api/user/map/share/sync/`, shareData, getAuthHeader())
             .then((response) => {
                 if (response.status === 200) {
                     this.closeModal();
@@ -67,7 +63,7 @@ class EmailShare extends Component {
     }
 
     render() {
-        let { mapToShare, mapId, emails, cancel } = this.props;
+        const { mapToShare, mapId, emails, cancel } = this.props;
         console.log("EMAILS", emails);
         return (
             <>
@@ -109,7 +105,11 @@ class EmailShare extends Component {
                         Cancel
                     </div>
                     <div className={`button rounded-button-full modal-button-confirm`}
-                        onClick={() => this.share(mapId)}
+                        onClick={() => {
+                            if (this.state.input != '')
+                                this.addEmail();
+                            this.share(mapId);
+                        }}
                     >
                         Share
                     </div>

--- a/src/components/modals/Share/EmailShare.js
+++ b/src/components/modals/Share/EmailShare.js
@@ -9,13 +9,36 @@ class EmailShare extends Component {
         super(props);
         this.state = {
             input: '',
-            emails: []
+            emails: [],
+            mapName: ''
         }
+    }
+
+    componentDidMount() {
+        const { myMaps, mapId } = this.props;
+        myMaps.forEach(map => {
+            if (map.map.eid == mapId) {
+                this.populateEmails(map.map.sharedWith);
+                this.setState({ mapName: map.map.name });
+            }
+        })
+    }
+
+    componentDidUpdate(prevProps) {
+        if ((prevProps.mapToShare === null) && (this.props.mapToShare !== null)) {
+            console.log("MAP TO SHARE VIA MYMAPS");
+            console.log("share", this.props.mapToShare);
+        }
+    }
+
+    populateEmails = (emails) => {
+        this.setState({ emails: emails.map(email => email.emailAddress) });
     }
 
     removeEmail = (i) => {
         const emails = this.state.emails.slice();
-        this.setState({ emails: emails.splice(i, 1) });
+        emails.splice(i, 1)
+        this.setState({ emails: emails });
     }
 
     addEmail = () => {
@@ -32,7 +55,13 @@ class EmailShare extends Component {
     }
 
     share(id) {
-        const { emails } = this.props;
+        const emails = this.state.emails.slice();
+        if (this.state.input != '') {
+            if (emailRegexp.test(this.state.input)) {
+                emails.push(this.state.input);
+                this.setState({ input: '', emails: emails });
+            }
+        }
         if (emails.length == 0)
             return;
         const shareData = {
@@ -55,19 +84,15 @@ class EmailShare extends Component {
             .catch((err) => console.log("share error", err));
     }
 
-    componentDidUpdate(prevProps) {
-        if ((prevProps.mapToShare === null) && (this.props.mapToShare !== null)) {
-            console.log("MAP TO SHARE VIA MYMAPS");
-            console.log("share", this.props.mapToShare);
-        }
-    }
-
     render() {
-        const { mapToShare, mapId, emails, cancel } = this.props;
+        const { mapId, cancel } = this.props;
+        const { emails, mapName } = this.state;
+        const emailsShared = this.props.emails;
         console.log("EMAILS", emails);
+        console.log("EMAILS shared", emailsShared)
         return (
             <>
-                <div className="modal-title">Share{mapToShare ? ` "${mapToShare.map.name}"` : ""}</div>
+                <div className="modal-title">Share {mapName}</div>
                 <div className="modal-content">
                     <input
                         className="text-input"
@@ -106,8 +131,6 @@ class EmailShare extends Component {
                     </div>
                     <div className={`button rounded-button-full modal-button-confirm`}
                         onClick={() => {
-                            if (this.state.input != '')
-                                this.addEmail();
                             this.share(mapId);
                         }}
                     >

--- a/src/reducers/ShareReducer.js
+++ b/src/reducers/ShareReducer.js
@@ -5,38 +5,13 @@ const INITIAL_STATE = {
 
 export default (state = INITIAL_STATE, action) => {
     let emails;
-    switch(action.type) {
+    switch (action.type) {
         case 'SET_MAP_TO_SHARE':
             emails = action.payload.map.sharedWith.map((email) => email.emailAddress);
             return {
                 ...state,
                 mapToShare: action.payload,
                 emails: emails,
-            }
-        case 'CLEAR_MAP_TO_SHARE':
-            return {
-                ...state,
-                mapToShare: null,
-                emails: [],
-            }
-        case 'POPULATE_MAP_TO_SHARE_EMAILS':
-            return {
-                ...state,
-                emails: action.payload
-            }
-        case 'ADD_SHARE_EMAIL':
-            emails = state.emails.slice();
-            emails.push(action.payload);
-            return {
-                ...state,
-                emails: emails
-            }
-        case 'REMOVE_SHARE_EMAIL':
-            emails = state.emails.slice();
-            emails.splice(action.payload, 1);
-            return {
-                ...state,
-                emails: emails
             }
         default:
             return state;


### PR DESCRIPTION
#### What? Why?

Closes #78 

UX for sharing maps was baffling, it didn't do anything when you pressed the button

#### What should we test?

Test sharing by email. Open a map, then click share in bottom left OR open my maps and click the little arrow in the row with the map name, this is the other way to open map sharing.

#### Release notes

There is more to do for sharing maps UX, basically making sure people now that the button SYNCS, so removing people's emails is actually removing their access, not just refraining from adding them again.

#### Deployment notes

nope


