### PR TITLE
Add Graceful Error Handling for Map Load Failure

### DIFF
--- a/src/components/modals/MyMaps.js
+++ b/src/components/modals/MyMaps.js
@@ -55,9 +55,32 @@ class MyMaps extends Component {
         });
     }
 
+    deleteMap() {
+        axios.post(`${constants.ROOT_URL}/api/user/map/delete/`, {
+            "eid": this.state.active.id
+        }, getAuthHeader())
+            .then((response) => {
+                if (this.state.active.id === currentMapId) {
+                    this.props.dispatch({ type: 'NEW_MAP' });
+                    this.props.drawControl.draw.deleteAll();
+                    setTimeout(() => {
+                        this.props.dispatch({ type: 'CHANGE_MOVING_METHOD', payload: 'flyTo' })
+                    });
+                }
+                axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+                    .then((response) => {
+                        this.props.dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
+                        this.setState({ trash: false });
+                    })
+                    .catch(() => {
+                        this.setState({ trash: false });
+                    })
+            });
+    }
+
     render() {
-        let { currentMapId } = this.props;
-        let myMaps = this.props.myMaps.filter((map) => map.access === 'WRITE');
+        const { currentMapId } = this.props;
+        const myMaps = this.props.myMaps.filter((map) => map.access === 'WRITE');
         if (this.state.trash) {
             return (
                 <Modal id="myMaps" padding={true}>
@@ -74,28 +97,7 @@ class MyMaps extends Component {
                             Cancel
                         </div>
                         <div className="button button-small"
-                            onClick={() => {
-                                axios.post(`${constants.ROOT_URL}/api/user/map/delete/`, {
-                                    "eid": this.state.active.id
-                                }, getAuthHeader())
-                                    .then((response) => {
-                                        if (this.state.active.id === currentMapId) {
-                                            this.props.dispatch({ type: 'NEW_MAP' });
-                                            this.props.drawControl.draw.deleteAll();
-                                            setTimeout(() => {
-                                                this.props.dispatch({ type: 'CHANGE_MOVING_METHOD', payload: 'flyTo' })
-                                            });
-                                        }
-                                        axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
-                                            .then((response) => {
-                                                this.props.dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
-                                                this.setState({ trash: false });
-                                            })
-                                            .catch(() => {
-                                                this.setState({ trash: false });
-                                            })
-                                    });
-                            }}
+                            onClick={this.deleteMap}
                         >
                             Delete
                         </div>
@@ -222,7 +224,12 @@ class MyMaps extends Component {
                 <Modal id="myMaps" padding={true}>
                     <div className="modal-title">My Maps</div>
                     <div className="modal-content modal-content-trash">
-                        <p>There are no maps.</p>
+                        {
+                            this.props.error ?
+                                <p>Map loading encountered the following error: {this.props.error}.</p>
+                                :
+                                <p>There are no maps.</p>
+                        }
                     </div>
                 </Modal>
             )
@@ -234,6 +241,7 @@ const mapStateToProps = ({ user, save, myMaps, mapMeta }) => ({
     user: user,
     savedMaps: save.savedMaps,
     myMaps: myMaps.maps,
+    error: myMaps.error,
     currentMapId: mapMeta.currentMapId
 });
 

--- a/src/components/modals/MySharedMaps.js
+++ b/src/components/modals/MySharedMaps.js
@@ -212,7 +212,12 @@ class MySharedMaps extends Component {
                 <Modal id="mySharedMaps" padding={true}>
                     <div className="modal-title">Shared Maps</div>
                     <div className="modal-content modal-content-trash">
-                        <p>There are no shared maps.</p>
+                        {
+                            this.props.error ?
+                                <p>Map loading encountered the following error: {this.props.error}.</p>
+                                :
+                                <p>There are no shared maps.</p>
+                        }
                     </div>
                 </Modal>
             )
@@ -224,6 +229,7 @@ const mapStateToProps = ({ user, save, myMaps, mapMeta }) => ({
     user: user,
     savedMaps: save.savedMaps,
     myMaps: myMaps.maps,
+    error: myMaps.error,
     currentMapId: mapMeta.currentMapId
 });
 

--- a/src/reducers/MyMapsReducer.js
+++ b/src/reducers/MyMapsReducer.js
@@ -1,12 +1,19 @@
 const INITIAL_STATE = {
-    maps: []
+    maps: [],
+    error: null
 }
 
 export default (state = INITIAL_STATE, action) => {
-    switch(action.type) {
+    switch (action.type) {
         case 'POPULATE_MY_MAPS':
             return {
-              maps: action.payload
+                ...state,
+                maps: action.payload
+            }
+        case 'MAP_ERROR':
+            return {
+                ...state,
+                error: action.payload
             }
         default:
             return state;

--- a/src/routes/MapApp.js
+++ b/src/routes/MapApp.js
@@ -81,8 +81,6 @@ class MapApp extends Component {
             if (maps.status === 200) {
                 this.props.dispatch({ type: 'POPULATE_MY_MAPS', payload: maps.data })
             }
-
-            throw "test error"
         }
         catch (err) {
             console.log("There was an error", err);


### PR DESCRIPTION
#### What? Why?

Closes #102 

Before, a failure to load the maps would logout the user. Now it just displays an error message in the maps section of the app.


#### What should we test?

The way I tested it was adding a `throw "test error"` line in the try block where the maps endpoint is called. I'm not sure how you'd test it without the maps failing, which they currently don't.

#### Release notes

The app no longer logs out the user if the map endpoint fails for some reason. Instead, an error message is displayed in the maps section.

#### Deployment notes

No.

