### PR TITLE
Make Polygons and Lines visible when coming from data groups

### DIFF
--- a/src/assets/styles/_datalayers.scss
+++ b/src/assets/styles/_datalayers.scss
@@ -67,7 +67,7 @@
 .popup-content{
   z-index: 4;
   position: absolute;
-  bottom: 45px;
+  bottom: 12px;
   left: -110px;
   background-color: white;
   width: 200px;
@@ -88,6 +88,11 @@
     border-width: 0 12px 12px 12px;
     border-color: transparent transparent white transparent;
     z-index: 99999;
+}
+
+.popup-with-marker{
+  position: absolute;
+  bottom: 45px;
 }
 
 .popup-title{

--- a/src/components/DataGroupLine.js
+++ b/src/components/DataGroupLine.js
@@ -1,0 +1,59 @@
+import React from "react";
+import { Marker, GeoJSONLayer } from "react-mapbox-gl";
+import DataGroupPopup from "./DataGroupPopup";
+import * as turf from '@turf/turf';
+
+const DataGroupLine = ({ line, setPopupVisible, popupVisible }) => {
+    const lineData = {
+        geometry: {
+            coordinates: line.vertices.coordinates,
+            type: 'LineString'
+        },
+        id: line.uuid,
+        properties: {},
+        type: "Feature"
+    }
+    line.center = turf.pointOnFeature(lineData);
+
+    const lineLayer = <GeoJSONLayer
+        key={line.uuid}
+        data={lineData}
+        linePaint={{
+            "line-color": "green",
+            "line-width": 2,
+            "line-opacity": 1,
+        }}
+        lineOnClick={() => setPopupVisible(line.uuid)}
+    />
+
+    if (popupVisible === line.uuid)
+        return <>
+            {lineLayer}
+            <Marker
+                key={line.uuid + "2"}
+                coordinates={line.center.geometry.coordinates}
+                name={line.name}
+                description={line.description}
+                anchor="bottom"
+                style={{
+                    height: "40px",
+                    zIndex: popupVisible == line.uuid ? 4 : 3
+                }}
+                onClick={() => {
+                    if (popupVisible !== line.uuid)
+                        setPopupVisible(line.uuid);
+                }}
+            >
+                <DataGroupPopup
+                    object={line}
+                    type={"line"}
+                    visible={popupVisible == line.uuid}
+                    closeDescription={() => setPopupVisible(-1)}
+                />
+            </Marker>
+        </>
+    else
+        return lineLayer;
+}
+
+export default DataGroupLine;

--- a/src/components/DataGroupMarker.js
+++ b/src/components/DataGroupMarker.js
@@ -1,0 +1,165 @@
+import React, { useState } from "react";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCertificate } from '@fortawesome/free-solid-svg-icons';
+import axios from "axios/index";
+import constants from "../constants";
+import { getAuthHeader } from "./Auth";
+import { useDispatch, useSelector } from "react-redux";
+import { Marker } from "react-mapbox-gl";
+
+const DataGroupMarkerContent = ({ marker, visible, closeDescription }) => {
+    const [mode, setMode] = useState("display");
+    const maps = useSelector((state) => state.myMaps.maps);
+    const [selectedMap, setSelectedMap] = useState();
+    const dispatch = useDispatch();
+
+    const addMarkerToMap = async () => {
+        const body = {
+            marker,
+            map: selectedMap
+        };
+
+        axios.post(`${constants.ROOT_URL}/api/user/map/save/marker`, body, getAuthHeader())
+            .then(() => {
+                axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+                    .then((response) => {
+                        dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
+
+                        const maps = response.data;
+
+                        maps.forEach(map => {
+                            if (map.map.eid === selectedMap.map.eid) {
+                                // this bit doesn't work
+                                axios.post(`${constants.ROOT_URL}/api/user/map/view/`, {
+                                    "eid": map.map.eid,
+                                }, getAuthHeader())
+                                //pick up the old name for the landDataLayers
+                                console.log(map)
+                                const savedMap = JSON.parse(map.map.data);
+
+                                if (savedMap.mapLayers.activeLayers) {
+                                    savedMap.mapLayers.landDataLayers = savedMap.mapLayers.activeLayers;
+                                }
+                                //fix that some have no dataLayers
+                                if (!savedMap.mapLayers.myDataLayers) {
+                                    savedMap.mapLayers.myDataLayers = [];
+                                }
+                                dispatch({
+                                    type: 'LOAD_MAP',
+                                    payload: savedMap,
+                                    id: map.map.eid
+                                });
+                            }
+                        })
+                    })
+            });
+
+    }
+
+    return (
+        <div>
+            <div
+                data-tooltip={marker.name}
+                className="pointer">
+                <div
+                    className="marker-icon-green"
+                    style={{
+                        height: 40,
+                        width: 40,
+                        zIndex: 2,
+                        position: "absolute",
+                        top: '0px',
+                        left: '-20px',
+                    }}
+                ></div>
+                <span
+                    style={{
+                        color: 'white',
+                        position: 'absolute',
+                        top: '4px',
+                        left: '-6px',
+                        zIndex: 3,
+                    }}
+                >
+                    <FontAwesomeIcon icon={faCertificate} />
+                </span>
+                <span className="marker-shadow"></span>
+            </div>
+            {visible && (mode === "display") && (
+                <div className="popup-content popup-with-marker">
+                    <div className="popup-close" onClick={closeDescription} />
+                    <h3 className="popup-title">{marker.name}</h3>
+                    <p className="description-text">{marker.description}</p>
+                    <div className="popup-save-icon-container" onClick={() => setMode("save")}>
+                        <div className="popup-save-icon" />
+                    </div>
+                </div>
+            )}
+            {visible && (mode === "save") && (
+                <div className="popup-content popup-with-marker">
+                    <div className="popup-close" onClick={() => { setMode("display"); closeDescription(); }} />
+                    <h3 className="popup-title">Save marker pin to:</h3>
+                    <div className="popup-save-map-container">
+                        {
+                            maps.map(map =>
+                                <p
+                                    className={`popup-save-map-option ${selectedMap && selectedMap.map.eid === map.map.eid && "save-map-highlighted"}`}
+                                    onClick={() => setSelectedMap(map)}
+                                >
+                                    {map.map.name}
+                                </p>)
+                        }
+                    </div>
+                    <div className="save-map-button"
+                        onClick={() => {
+                            if (selectedMap) {
+                                addMarkerToMap(marker, selectedMap);
+                                setMode("complete");
+                            }
+                        }}
+                    > Save</div>
+                </div>
+            )}
+            {visible && (mode === "complete") && (
+                <div className="popup-content popup-with-marker">
+                    <p className="popup-save-success-text">
+                        Marker pin successfully saved to
+                        <br />
+                        '{selectedMap.map.name}'
+                    </p>
+                    <div className="save-map-button"
+                        onClick={() => {
+                            closeDescription();
+                            setMode("display");
+                        }}
+                    > Ok</div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+const DataGroupMarker = ({ coordinates, name, description, marker, popupVisible, setPopupVisible }) =>
+    <Marker
+        key={marker.uuid}
+        coordinates={coordinates}
+        name={name}
+        description={description}
+        anchor="bottom"
+        style={{
+            height: "40px",
+            zIndex: popupVisible == marker.uuid ? 4 : 3
+        }}
+        onClick={() => {
+            if (popupVisible !== marker.uuid)
+                setPopupVisible(marker.uuid);
+        }}
+    >
+        <DataGroupMarkerContent
+            marker={marker}
+            visible={popupVisible == marker.uuid}
+            closeDescription={() => setPopupVisible(-1)}
+        />
+    </Marker>
+
+export default DataGroupMarker;

--- a/src/components/DataGroupPolygon.js
+++ b/src/components/DataGroupPolygon.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { Marker, GeoJSONLayer } from "react-mapbox-gl";
+import DataGroupPopup from "./DataGroupPopup";
+
+const DataGroupPolygon = ({ polygon, setPopupVisible, popupVisible }) => {
+    const polygonData = {
+        geometry: {
+            coordinates: polygon.vertices.coordinates,
+            type: 'Polygon'
+        },
+        id: polygon.uuid,
+        properties: {},
+        type: "Feature"
+    }
+
+    const polygonLayer = <GeoJSONLayer
+        key={polygon.uuid}
+        data={polygonData}
+        linePaint={{
+            "line-color": "green",
+            "line-width": 2,
+            "line-opacity": 1,
+        }}
+        fillPaint={{
+            "fill-color": "green",
+            "fill-opacity": .05,
+        }}
+        fillOnClick={() => setPopupVisible(polygon.uuid)}
+    />
+
+    if (popupVisible === polygon.uuid)
+        return <>
+            {polygonLayer}
+            <Marker
+                key={polygon.uuid + "2"}
+                coordinates={polygon.center.coordinates}
+                name={polygon.name}
+                description={polygon.description}
+                anchor="bottom"
+                style={{
+                    height: "40px",
+                    zIndex: popupVisible == polygon.uuid ? 4 : 3
+                }}
+                onClick={() => {
+                    if (popupVisible !== polygon.uuid)
+                        setPopupVisible(polygon.uuid);
+                }}
+            >
+                <DataGroupPopup
+                    object={polygon}
+                    type={"polygon"}
+                    visible={popupVisible == polygon.uuid}
+                    closeDescription={() => setPopupVisible(-1)}
+                />
+            </Marker>
+        </>
+    else
+        return polygonLayer;
+}
+
+export default DataGroupPolygon;

--- a/src/components/DataGroupPopup.js
+++ b/src/components/DataGroupPopup.js
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import axios from "axios/index";
+import constants from "../constants";
+import { getAuthHeader } from "./Auth";
+import { useDispatch, useSelector } from "react-redux";
+
+const DataGroupPopup = ({ object, type, visible, closeDescription }) => {
+    const [mode, setMode] = useState("display");
+    const maps = useSelector((state) => state.myMaps.maps);
+    const [selectedMap, setSelectedMap] = useState();
+    const dispatch = useDispatch();
+
+    const addObjectToMap = async () => {
+        const body = {}
+        body[type] = object;
+        body.map = selectedMap;
+
+        axios.post(`${constants.ROOT_URL}/api/user/map/save/${type}`, body, getAuthHeader())
+            .then(() => {
+                axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+                    .then((response) => {
+                        dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
+
+                        const maps = response.data;
+
+                        maps.forEach(map => {
+                            if (map.map.eid === selectedMap.map.eid) {
+                                // this bit doesn't work
+                                axios.post(`${constants.ROOT_URL}/api/user/map/view/`, {
+                                    "eid": map.map.eid,
+                                }, getAuthHeader())
+                                //pick up the old name for the landDataLayers
+                                console.log(map)
+                                const savedMap = JSON.parse(map.map.data);
+
+                                if (savedMap.mapLayers.activeLayers) {
+                                    savedMap.mapLayers.landDataLayers = savedMap.mapLayers.activeLayers;
+                                }
+                                //fix that some have no dataLayers
+                                if (!savedMap.mapLayers.myDataLayers) {
+                                    savedMap.mapLayers.myDataLayers = [];
+                                }
+                                dispatch({
+                                    type: 'LOAD_MAP',
+                                    payload: savedMap,
+                                    id: map.map.eid
+                                });
+                            }
+                        })
+                    })
+            });
+
+    }
+
+    return (
+        <div>
+            {visible && (mode === "display") && (
+                <div className="popup-content">
+                    <div className="popup-close" onClick={closeDescription} />
+                    <h3 className="popup-title">{object.name}</h3>
+                    <p className="description-text">{object.description}</p>
+                    <div className="popup-save-icon-container" onClick={() => setMode("save")}>
+                        <div className="popup-save-icon" />
+                    </div>
+                </div>
+            )}
+            {visible && (mode === "save") && (
+                <div className="popup-content">
+                    <div className="popup-close" onClick={() => { setMode("display"); closeDescription(); }} />
+                    <h3 className="popup-title">Save {type} to:</h3>
+                    <div className="popup-save-map-container">
+                        {
+                            maps.map(map =>
+                                <p
+                                    className={`popup-save-map-option ${selectedMap && selectedMap.map.eid === map.map.eid && "save-map-highlighted"}`}
+                                    onClick={() => setSelectedMap(map)}
+                                >
+                                    {map.map.name}
+                                </p>)
+                        }
+                    </div>
+                    <div className="save-map-button"
+                        onClick={() => {
+                            if (selectedMap) {
+                                addObjectToMap(object, selectedMap);
+                                setMode("complete");
+                            }
+                        }}
+                    > Save</div>
+                </div>
+            )}
+            {visible && (mode === "complete") && (
+                <div className="popup-content">
+                    <p className="popup-save-success-text">
+                        {type == "polygon" ? "Polygon" : "Line"} successfully saved to
+                        <br />
+                        '{selectedMap.map.name}'
+                    </p>
+                    <div className="save-map-button"
+                        onClick={() => {
+                            closeDescription();
+                            setMode("display");
+                        }}
+                    > Ok</div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default DataGroupPopup;

--- a/src/components/Drawing.js
+++ b/src/components/Drawing.js
@@ -21,18 +21,20 @@ class Drawing extends Component {
     }
 
     render() {
-        let { polygon, type, activePolygon, activeTool, readOnly, baseLayer } = this.props;
-        let { editing, hidden } = this.state;
-        let polygonId = polygon.data.id;
+        let { polygon } = this.props;
+        const { type, activePolygon, activeTool, readOnly, baseLayer } = this.props;
+        const { editing, hidden } = this.state;
+        const polygonId = polygon.data.id;
         polygon = polygon.data;
-        let isActive = polygonId === activePolygon;
-        let center = turf.pointOnFeature(polygon);
-        let showPopup = isActive && !activeTool;
-        let popup = {
+        const isActive = polygonId === activePolygon;
+        const center = turf.pointOnFeature(polygon);
+        const showPopup = isActive && !activeTool;
+        const popup = {
             coordinates: center.geometry.coordinates,
             name: this.props.name,
         };
         console.log("ACTIVE TOOL", activeTool);
+        console.log(polygon)
         return (
             <div>
                 {
@@ -53,8 +55,8 @@ class Drawing extends Component {
                                 if (activeTool !== 'drop-pin') {
                                     if (!(activeTool)) {
                                         console.log("the polygon was clicked", e);
-                                        let area = turf.area(polygon);
-                                        let roundedArea = Math.round(area * 100) / 100;
+                                        const area = turf.area(polygon);
+                                        const roundedArea = Math.round(area * 100) / 100;
                                         if (isActive) {
                                             this.props.dispatch({
                                                 type: 'CLEAR_ACTIVE_POLYGON',

--- a/src/components/MapDataGroups.js
+++ b/src/components/MapDataGroups.js
@@ -1,145 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCertificate } from '@fortawesome/free-solid-svg-icons';
 import axios from "axios/index";
 import constants from "../constants";
 import { getAuthHeader } from "./Auth";
 import { useDispatch, useSelector } from "react-redux";
 import { Cluster, Marker } from "react-mapbox-gl";
-
-const DataGroupMarkerContent = ({ marker, visible, closeDescription }) => {
-  const [mode, setMode] = useState("display");
-  const maps = useSelector((state) => state.myMaps.maps);
-  const [selectedMap, setSelectedMap] = useState();
-  const dispatch = useDispatch();
-
-  const addMarkerToMap = async () => {
-    const body = {
-      marker,
-      map: selectedMap
-    };
-
-    axios.post(`${constants.ROOT_URL}/api/user/map/save/marker`, body, getAuthHeader())
-      .then(() => {
-        axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
-          .then((response) => {
-            dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
-
-            const maps = response.data;
-
-            maps.forEach(map => {
-              if (map.map.eid === selectedMap.map.eid) {
-                // this bit doesn't work
-                axios.post(`${constants.ROOT_URL}/api/user/map/view/`, {
-                  "eid": map.map.eid,
-                }, getAuthHeader())
-                //pick up the old name for the landDataLayers
-                console.log(map)
-                const savedMap = JSON.parse(map.map.data);
-
-                if (savedMap.mapLayers.activeLayers) {
-                  savedMap.mapLayers.landDataLayers = savedMap.mapLayers.activeLayers;
-                }
-                //fix that some have no dataLayers
-                if (!savedMap.mapLayers.myDataLayers) {
-                  savedMap.mapLayers.myDataLayers = [];
-                }
-                dispatch({
-                  type: 'LOAD_MAP',
-                  payload: savedMap,
-                  id: map.map.eid
-                });
-              }
-            })
-          })
-      });
-
-  }
-
-  return (
-    <div>
-      <div
-        data-tooltip={marker.name}
-        className="pointer">
-        <div
-          className="marker-icon-green"
-          style={{
-            height: 40,
-            width: 40,
-            zIndex: 2,
-            position: "absolute",
-            top: '0px',
-            left: '-20px',
-          }}
-        ></div>
-        <span
-          style={{
-            color: 'white',
-            position: 'absolute',
-            top: '4px',
-            left: '-6px',
-            zIndex: 3,
-          }}
-        >
-          <FontAwesomeIcon icon={faCertificate} />
-        </span>
-        <span className="marker-shadow"></span>
-      </div>
-      {visible && (mode === "display") && (
-        <div className="popup-content">
-          <div className="popup-close" onClick={closeDescription} />
-          <h3 className="popup-title">{marker.name}</h3>
-          <p className="description-text">{marker.description}</p>
-          <div className="popup-save-icon-container" onClick={() => setMode("save")}>
-            <div className="popup-save-icon" />
-          </div>
-        </div>
-      )}
-      {visible && (mode === "save") && (
-        <div className="popup-content">
-          <div className="popup-close" onClick={() => { setMode("display"); closeDescription(); }} />
-          <h3 className="popup-title">Save marker pin to:</h3>
-          <div className="popup-save-map-container">
-            {
-              maps.map(map =>
-                <p
-                  className={`popup-save-map-option ${selectedMap && selectedMap.map.eid === map.map.eid && "save-map-highlighted"}`}
-                  onClick={() => setSelectedMap(map)}
-                >
-                  {map.map.name}
-                </p>)
-            }
-          </div>
-          <div className="save-map-button"
-            onClick={() => {
-              if (selectedMap) {
-                addMarkerToMap(marker, selectedMap);
-                setMode("complete");
-              }
-            }}
-          > Save</div>
-        </div>
-      )}
-      {visible && (mode === "complete") && (
-        <div className="popup-content">
-          <p className="popup-save-success-text">
-            Marker pin successfully saved to
-            <br />
-            '{selectedMap.map.name}'
-          </p>
-          <div className="save-map-button"
-            onClick={() => {
-              closeDescription();
-              setMode("display");
-            }}
-          > Ok</div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-
+import DataGroupMarker from "./DataGroupMarker";
+import DataGroupPolygon from "./DataGroupPolygon";
+import DataGroupLine from "./DataGroupLine";
 
 const ClusterMarker = (coordinates, pointCount) => {
   return (
@@ -157,7 +24,7 @@ const ClusterMarker = (coordinates, pointCount) => {
   );
 };
 
-const MapDataGroups = ({ markerVisible, setMarkerVisible }) => {
+const MapDataGroups = ({ popupVisible, setPopupVisible }) => {
   const dispatch = useDispatch();
   const [dataGroups, setDataGroups] = useState();
   const activeGroups = useSelector((state) => state.dataGroups.activeGroups);
@@ -213,34 +80,41 @@ const MapDataGroups = ({ markerVisible, setMarkerVisible }) => {
   });
 
   const dataGroupMarkers = [];
+  const dataGroupPolygons = [];
+  const dataGroupLines = [];
 
   activeDataGroups &&
     activeDataGroups.forEach((dataGroup) => {
       dataGroup.markers.forEach((marker) => {
         dataGroupMarkers.push(
-          <Marker
+          <DataGroupMarker
             key={marker.idmarkers}
             coordinates={marker.location.coordinates}
             name={marker.name}
             description={marker.description}
-            anchor="bottom"
-            style={{
-              height: "40px",
-              zIndex: markerVisible == marker.idmarkers ? 4 : 3
-            }}
-            onClick={() => {
-              if (markerVisible != marker.idmarkers)
-                setMarkerVisible(marker.idmarkers);
-            }}
-          >
-            <DataGroupMarkerContent
-              marker={marker}
-              visible={markerVisible == marker.idmarkers}
-              closeDescription={() => setMarkerVisible(-1)}
-            />
-          </Marker>
-        );
+            marker={marker}
+            popupVisible={popupVisible}
+            setPopupVisible={setPopupVisible}
+          />)
       });
+      dataGroup.polygons.forEach((polygon) => {
+        dataGroupPolygons.push(
+          <DataGroupPolygon
+            polygon={polygon}
+            setPopupVisible={setPopupVisible}
+            popupVisible={popupVisible}
+          />
+        )
+      });
+      dataGroup.lines.forEach((line) => {
+        dataGroupLines.push(
+          <DataGroupLine
+            line={line}
+            setPopupVisible={setPopupVisible}
+            popupVisible={popupVisible}
+          />
+        )
+      })
     });
 
   return (
@@ -250,6 +124,8 @@ const MapDataGroups = ({ markerVisible, setMarkerVisible }) => {
           {dataGroupMarkers}
         </Cluster>
       )}
+      {dataGroupPolygons}
+      {dataGroupLines}
     </>
   );
 };

--- a/src/components/MapboxMap.js
+++ b/src/components/MapboxMap.js
@@ -41,7 +41,7 @@ class MapboxMap extends Component {
       styleLoaded: false,
       drawings: null,
       redrawing: false,
-      markerVisible: -1,
+      popupVisible: -1,
     };
     // ref to the mapbox map
     this.map = null;
@@ -60,7 +60,7 @@ class MapboxMap extends Component {
   }
 
   onClick = (map, evt) => {
-    this.setState({ markerVisible: -1 });
+    this.setState({ popupVisible: -1 });
 
     const mode = this.drawControl.draw.getMode();
     if (mode === "simple_select") {
@@ -230,7 +230,7 @@ class MapboxMap extends Component {
   };
 
   render() {
-    const { markerVisible } = this.state;
+    const { popupVisible } = this.state;
     const {
       zoom,
       lngLat,
@@ -289,9 +289,9 @@ class MapboxMap extends Component {
           <MapLayers />
           {/* Map Data Groups displaying My Data */}
           <MapDataGroups
-            markerVisible={markerVisible}
-            setMarkerVisible={(markerId) =>
-              this.setState({ markerVisible: markerId })
+            popupVisible={popupVisible}
+            setPopupVisible={(markerId) =>
+              this.setState({ popupVisible: markerId })
             }
           />
           {council /* Map Council Layers (wards etc.)*/ && (


### PR DESCRIPTION
#### What? Why?

Closes #121

Polygons and Lines didn't have data group components that would display on the map even if they existed in the data group database.


#### What should we test?

turn on a data layer that has polygons and lines in. The default test user has such a layer.
Click on the polygons and lines to add them to a map.

#### Release notes

- Data Groups can now include polygons and lines which can also be converted to drawn objects on maps.


#### Deployment notes

- Ensure migration and seeding scripts are run



