### PR TITLE
Add clustering to drawn items

### DIFF
--- a/src/assets/styles/_datalayers.scss
+++ b/src/assets/styles/_datalayers.scss
@@ -53,6 +53,14 @@
   width: 30px;
 }
 
+.cluster-grey{
+  background-color: #78838f;
+}
+
+.cluster-grey-transparent{
+  background-color: #78838f80;
+}
+
 .cluster-text{
     color: white;
     border-radius: 50%;

--- a/src/components/Markers.js
+++ b/src/components/Markers.js
@@ -1,7 +1,23 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import MarkerPin from './MarkerPin';
-import { Marker } from 'react-mapbox-gl';
+import { Cluster, Marker } from 'react-mapbox-gl';
+
+const ClusterMarker = (coordinates, pointCount) => {
+    return (
+        <Marker
+            key={coordinates.toString()}
+            coordinates={coordinates}
+            style={{ height: "40px", zIndex: 2 }}
+        >
+            <div className="cluster-container cluster-grey-transparent">
+                <div className="cluster-background cluster-grey">
+                    <p className="cluster-text">{pointCount}</p>
+                </div>
+            </div>
+        </Marker>
+    );
+};
 
 class Markers extends Component {
 
@@ -86,13 +102,18 @@ class Markers extends Component {
                         </Marker>
                     )
                 }
-                {markers && markers.map((marker) => (
-                    <MarkerPin
-                        key={marker.uuid}
-                        marker={marker}
-                        handleMarkerClick={this.handleMarkerClick}
-                    />
-                ))}
+                {
+                    markers && <Cluster ClusterMarkerFactory={ClusterMarker}>
+                        {markers.map((marker) => (
+                            <MarkerPin
+                                key={marker.uuid}
+                                coordinates={marker.coordinates}
+                                marker={marker}
+                                handleMarkerClick={this.handleMarkerClick}
+                            />
+                        ))}
+                    </Cluster>
+                }
             </React.Fragment>
         );
     }


### PR DESCRIPTION
#### What? Why?

Adds clustering to drawn markers, so that there's consistency 


#### What should we test?

1. draw some markers near to each other
2. zoom out to see the clustering

#### Release notes

Drawn items cluster like data group items now.


#### Deployment notes

Nope



