### PR TITLE
Change expand button to chevron icon

### DIFF
--- a/src/assets/styles/_datalayers.scss
+++ b/src/assets/styles/_datalayers.scss
@@ -1,18 +1,10 @@
-.data-section-title-container {
+.data-section-title {
+  cursor: pointer;
+  position: relative;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   padding: 0px 25px;
-}
-
-.data-section-title {
-  cursor: pointer;
-  font-size: 16px;
-  font-weight: bold;
-}
-
-.expand-button {
-  cursor: pointer;
 }
 
 /* Tooltips for data group markers  */

--- a/src/components/NavLandData.js
+++ b/src/components/NavLandData.js
@@ -9,9 +9,25 @@ const DataLayersContainer = ({ children, title }) => {
     const [expanded, setExpanded] = useState(true);
 
     return <div>
-        <div className='data-section-title-container'>
-            <h3 className='data-section-title' onClick={() => setExpanded(!expanded)}>{title}</h3>
-            <p className='expand-button' onClick={() => setExpanded(!expanded)}>{expanded ? "v" : "<"}</p>
+        <div className='data-section-title' onClick={() => setExpanded(!expanded)}>
+            <h4 style={{ fontWeight: 'bold' }}>{title}</h4>
+            <div style={{
+                position: 'absolute',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                right: '12px',
+                width: '24px',
+                height: '24px',
+                textAlign: 'center'
+            }}>
+                <img
+                    src={require('../assets/img/chevron.svg')} alt=""
+                    style={{
+                        transformOrigin: 'center',
+                        transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                    }}
+                />
+            </div>
         </div>
         {expanded && children}
     </div>


### PR DESCRIPTION
#### What? Why?

Closes #134 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Change the icon in the layers section so that it is consistent across the app.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Open a new map and draw a marker/polygon
- Have a look at the behaviour of the expand button when expanding + collapsing a drawing's info
- Go to the layer panel and expand + collapse a section. The expand icon should look and behave the same.

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
