### PR TITLE
Zoom in when clicking a cluster

### DIFF
--- a/src/components/MapCommunityAssets.js
+++ b/src/components/MapCommunityAssets.js
@@ -391,11 +391,18 @@ class MapCommunityAssets extends Component {
 
     activeLayers = this.packDuplicateCoordinate(activeLayers);
     if (activeLayers.length > 0) {
+      let { radius } = this.state;
+      // Zoom in to the minimum level that separates a cluster, if the nodes are exactly aligned
+      // along the shortest screen axis. We will zoom in too much if this isn't the case, but the
+      // Cluster component doesn't give us enough control to do any better.
+      let paddingOnZoom = Math.min(window.innerHeight, window.innerWidth) / 2 - radius - 30;
       nodes.push(
         <Cluster
           key="1"
           ClusterMarkerFactory={this[activeLayersId[0]]}
-          radius={this.state.radius}
+          radius={radius}
+          zoomOnClick={true}
+          zoomOnClickPadding={paddingOnZoom}
         >
           {activeLayers.map(this.createNodalBackEnd)}
         </Cluster>

--- a/src/components/MapDataGroups.js
+++ b/src/components/MapDataGroups.js
@@ -120,10 +120,21 @@ const MapDataGroups = ({ popupVisible, setPopupVisible }) => {
         })
     });
 
+  const clusterRadius = 60;
+  // Zoom in to the minimum level that separates a cluster, if the nodes are exactly aligned
+  // along the shortest screen axis. We will zoom in too much if this isn't the case, but the
+  // Cluster component doesn't give us enough control to do any better.
+  const paddingOnZoom = Math.min(window.innerHeight, window.innerWidth) / 2 - clusterRadius - 40;
+
   return (
     <>
       {dataGroupMarkers && (
-        <Cluster ClusterMarkerFactory={ClusterMarker}>
+        <Cluster
+          ClusterMarkerFactory={ClusterMarker}
+          radius={clusterRadius}
+          zoomOnClick={true}
+          zoomOnClickPadding={paddingOnZoom}
+        >
           {dataGroupMarkers}
         </Cluster>
       )}

--- a/src/components/Markers.js
+++ b/src/components/Markers.js
@@ -70,40 +70,46 @@ class Markers extends Component {
         let { markers, searchMarker, currentLocation } = this.props;
         console.log("marker map?", this.props.map);
         console.log("search marker", searchMarker);
+        let clusterRadius = 60;
+        // Zoom in to the minimum level that separates a cluster, if the nodes are exactly aligned
+        // along the shortest screen axis. We will zoom in too much if this isn't the case, but the
+        // Cluster component doesn't give us enough control to do any better.
+        let paddingOnZoom = Math.min(window.innerHeight, window.innerWidth) / 2 - clusterRadius - 40;
         return (
             <React.Fragment>
-                {
-                    searchMarker && (
-                        <Marker
-                            coordinates={searchMarker}
-                            style={{ zIndex: 1 }}
-                        >
-                            <img src={require('../assets/img/icon-marker-new--red.svg')} alt=""
-                                style={{
-                                    height: 40,
-                                    width: 40
-                                }}
-                            />
-                        </Marker>
-                    )
-                }
-                {
-                    currentLocation && (
-                        <Marker
-                            coordinates={currentLocation}
-                            style={{ zIndex: 1 }}
-                        >
-                            <img src={require('../assets/img/icon-current-location--blue.svg')} alt=""
-                                style={{
-                                    height: 30,
-                                    width: 30
-                                }}
-                            />
-                        </Marker>
-                    )
-                }
-                {
-                    markers && <Cluster ClusterMarkerFactory={ClusterMarker}>
+                {searchMarker && (
+                    <Marker
+                        coordinates={searchMarker}
+                        style={{ zIndex: 1 }}
+                    >
+                        <img src={require('../assets/img/icon-marker-new--red.svg')} alt=""
+                            style={{
+                                height: 40,
+                                width: 40
+                            }}
+                        />
+                    </Marker>
+                )}
+                {currentLocation && (
+                    <Marker
+                        coordinates={currentLocation}
+                        style={{ zIndex: 1 }}
+                    >
+                        <img src={require('../assets/img/icon-current-location--blue.svg')} alt=""
+                            style={{
+                                height: 30,
+                                width: 30
+                            }}
+                        />
+                    </Marker>
+                )}
+                {markers && (
+                    <Cluster
+                        ClusterMarkerFactory={ClusterMarker}
+                        radius={clusterRadius}
+                        zoomOnClick={true}
+                        zoomOnClickPadding={paddingOnZoom}
+                    >
                         {markers.map((marker) => (
                             <MarkerPin
                                 key={marker.uuid}
@@ -113,7 +119,7 @@ class Markers extends Component {
                             />
                         ))}
                     </Cluster>
-                }
+                )}
             </React.Fragment>
         );
     }


### PR DESCRIPTION
#### What? Why?

Closes #144 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When a drawn marker is in a cluster with nearby markers, nothing happens if you click the cluster. The only way to make anything happen is to zoom in enough that the cluster separates, then you can see individual marker popups.

This change makes the map zoom in when clicking a cluster, so that it separates. And it also makes the popup appear from a cluster if that marker is clicked in the info side panel.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1) Draw two or more markers close to each other
2) Zoom out until they cluster.
3) Click the cluster and the map should zoom back in
4) Zoom out again until the cluster.
5) Click a marker on the info side panel. The popup for that marker should appear from the cluster, without zooming in.
6) Then click on the cluster. It should zoom in and the popup should stay open for the active marker.

- Repeat steps 2 & 3 for nearby markers in the RGS layer.

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
