### PR TITLE
Change order of land ownership and data layers

### DIFF
--- a/src/components/NavLandData.js
+++ b/src/components/NavLandData.js
@@ -59,6 +59,13 @@ const NavLandData = ({ open, active, onClose }) => {
                     <NavTrayItem draggable={true} title="Brownfield" layerId='ncc-brownfield-sites' />
                 </Draggable>
             </DataLayersContainer>
+            <DataLayersContainer title={"Land Ownership"}>
+                <DataToggle
+                    title={"Land Registry"}
+                    active={displayProperties}
+                    onToggle={() => dispatch({ type: "TOGGLE_PROPERTY_DISPLAY" })}
+                />
+            </DataLayersContainer>
             {userGroupTitlesAndIDs && userGroupTitlesAndIDs.map(userGroup =>
                 <DataLayersContainer title={userGroup.title} key={userGroup.id}>
                     {dataGroupTitlesAndIDs && dataGroupTitlesAndIDs.filter(dataGroup => dataGroup.userGroupId == userGroup.id).map(dataGroup =>
@@ -73,13 +80,6 @@ const NavLandData = ({ open, active, onClose }) => {
                         />)}
                 </DataLayersContainer>
             )}
-            <DataLayersContainer title={"Land Ownership"}>
-                <DataToggle
-                    title={"Land Registry"}
-                    active={displayProperties}
-                    onToggle={() => dispatch({ type: "TOGGLE_PROPERTY_DISPLAY" })}
-                />
-            </DataLayersContainer>
         </NavTray>
     );
 }


### PR DESCRIPTION
#### What? Why?

Closes #136 

Universal data layers are grouped together at the top, user layers at the bottom


#### What should we test?

- Log in as user with user group membership
- Open data layers
- Verify that land ownership is above user group layers

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

nope


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
