### PR TITLE
LX-123 Editable Descriptions of Drawn Objects

### DIFF
--- a/src/assets/styles/_datalayers.scss
+++ b/src/assets/styles/_datalayers.scss
@@ -54,14 +54,18 @@
 }
 
 .cluster-text{
-    color: white;
-    border-radius: 50%;
-    margin: 0px;
-    height: 30px;
-    width: 30px;
-    text-align: center;
-    font-size: 18px;
-    padding-top: 5px;
+  color: white;
+  border-radius: 50%;
+  margin: 0px;
+  height: 30px;
+  width: 30px;
+  text-align: center;
+  font-size: 18px;
+  padding-top: 5px;
+}
+
+.cluster-text-active{
+  color: #2ecc71;
 }
 
 .popup-content{

--- a/src/components/DataGroupLine.js
+++ b/src/components/DataGroupLine.js
@@ -47,7 +47,6 @@ const DataGroupLine = ({ line, setPopupVisible, popupVisible }) => {
                 <DataGroupPopup
                     object={line}
                     type={"line"}
-                    visible={popupVisible == line.uuid}
                     closeDescription={() => setPopupVisible(-1)}
                 />
             </Marker>

--- a/src/components/DataGroupMarker.js
+++ b/src/components/DataGroupMarker.js
@@ -38,12 +38,11 @@ const DataGroupMarkerContent = ({ marker, visible, closeDescription }) => {
                 position: "relative",
                 bottom: "-5px",
             }}>
-                <DataGroupPopup
+                {visible && <DataGroupPopup
                     object={marker}
                     type={"marker"}
-                    visible={visible}
                     closeDescription={closeDescription}
-                />
+                />}
             </div>
 
         </div>
@@ -59,7 +58,7 @@ const DataGroupMarker = ({ coordinates, name, description, marker, popupVisible,
         anchor="bottom"
         style={{
             height: "40px",
-            zIndex: popupVisible == marker.uuid ? 4 : 3
+            zIndex: popupVisible === marker.uuid ? 4 : 3
         }}
         onClick={() => {
             if (popupVisible !== marker.uuid)
@@ -68,7 +67,7 @@ const DataGroupMarker = ({ coordinates, name, description, marker, popupVisible,
     >
         <DataGroupMarkerContent
             marker={marker}
-            visible={popupVisible == marker.uuid}
+            visible={popupVisible === marker.uuid}
             closeDescription={() => setPopupVisible(-1)}
         />
     </Marker>

--- a/src/components/DataGroupPolygon.js
+++ b/src/components/DataGroupPolygon.js
@@ -49,7 +49,6 @@ const DataGroupPolygon = ({ polygon, setPopupVisible, popupVisible }) => {
                 <DataGroupPopup
                     object={polygon}
                     type={"polygon"}
-                    visible={popupVisible == polygon.uuid}
                     closeDescription={() => setPopupVisible(-1)}
                 />
             </Marker>

--- a/src/components/DataGroupPopup.js
+++ b/src/components/DataGroupPopup.js
@@ -5,7 +5,7 @@ import { getAuthHeader } from "../utils/Auth";
 import { useDispatch, useSelector } from "react-redux";
 import { saveExistingMap } from "../utils/saveMap";
 
-const DataGroupPopup = ({ object, type, visible, closeDescription }) => {
+const DataGroupPopup = ({ object, type, closeDescription }) => {
     const [mode, setMode] = useState("display");
     const [name, setName] = useState(object.name);
     const [description, setDescription] = useState(object.description);
@@ -39,117 +39,112 @@ const DataGroupPopup = ({ object, type, visible, closeDescription }) => {
     }
 
     return (
-        <div>
-            {visible && <div className="popup-content">
-                <div className="popup-close" onClick={closeDescription} />
-                {(mode === "display") && (
-                    <>
-                        <div className="popup-body-container">
-                            <h3 className="popup-title">{name}</h3>
-                            <div className="popup-body-main">
-                                <p className="description-text">{description}</p>
-                            </div>
+        <div className="popup-content">
+            <div className="popup-close" onClick={closeDescription} />
+            {(mode === "display") && (
+                <>
+                    <div className="popup-body-container">
+                        <h3 className="popup-title">{name}</h3>
+                        <div className="popup-body-main">
+                            <p className="description-text">{description}</p>
                         </div>
-                        <div className="popup-sidebar">
-                            <img src={require("../assets/img/icon-add.svg")}
-                                onClick={() => { setMode("save") }}
-                                className="popup-sidebar-button"
-                            />
-                            <img src={require("../assets/img/icon-pencil.svg")}
-                                className="popup-sidebar-button"
-                                onClick={() => setMode("edit")}
-                            />
+                    </div>
+                    <div className="popup-sidebar">
+                        <img src={require("../assets/img/icon-add.svg")}
+                            onClick={() => { setMode("save") }}
+                            className="popup-sidebar-button"
+                        />
+                        <img src={require("../assets/img/icon-pencil.svg")}
+                            className="popup-sidebar-button"
+                            onClick={() => setMode("edit")}
+                        />
+                    </div>
+                </>
+            )}
+            {(mode === "edit") && (
+                <>
+                    <div className="popup-body-container">
+                        <h3 className="popup-title editable" id="popup-name" contentEditable>{name}</h3>
+                        <div className="popup-body-main">
+                            <p className="description-text editable" id="popup-description" contentEditable>{description}</p>
                         </div>
-                    </>
-                )}
-                {(mode === "edit") && (
-                    <>
-
-                        <div className="popup-body-container">
-                            <h3 className="popup-title editable" id="popup-name" contentEditable>{name}</h3>
-                            <div className="popup-body-main">
-                                <p className="description-text editable" id="popup-description" contentEditable>{description}</p>
-                            </div>
+                    </div>
+                    <div className="popup-sidebar">
+                        <img src={require("../assets/img/icon-cross.svg")}
+                            onClick={() => {
+                                setName(object.name);
+                                setDescription(object.description);
+                                setMode("display");
+                            }}
+                            className="popup-sidebar-button"
+                        />
+                        <img src={require("../assets/img/icon-tick.svg")}
+                            className="popup-sidebar-button"
+                            onClick={() => {
+                                const newName = document.getElementById("popup-name").textContent;
+                                const newDescription = document.getElementById("popup-description").textContent;
+                                setName(newName);
+                                setDescription(newDescription);
+                                setMode("display");
+                                editObject(newName, newDescription);
+                            }}
+                        />
+                    </div>
+                </>
+            )}
+            {(mode === "save") && (
+                <>
+                    <div className="popup-body-container">
+                        <h3 className="popup-title">Save {type} to:</h3>
+                        <div className="popup-body-main">
+                            {
+                                maps.map(map =>
+                                    <p
+                                        className={`popup-save-map-option ${selectedMap && selectedMap.map.eid === map.map.eid && "save-map-highlighted"}`}
+                                        onClick={() => setSelectedMap(map)}
+                                    >
+                                        {map.map.name}
+                                    </p>)
+                            }
                         </div>
-                        <div className="popup-sidebar">
-                            <img src={require("../assets/img/icon-cross.svg")}
-                                onClick={() => {
-                                    setName(object.name);
-                                    setDescription(object.description);
-                                    setMode("display");
-                                }}
-                                className="popup-sidebar-button"
-                            />
-                            <img src={require("../assets/img/icon-tick.svg")}
-                                className="popup-sidebar-button"
-                                onClick={() => {
-                                    const newName = document.getElementById("popup-name").textContent;
-                                    const newDescription = document.getElementById("popup-description").textContent;
-                                    setName(newName);
-                                    setDescription(newDescription);
-                                    setMode("display");
-                                    editObject(newName, newDescription);
-                                }}
-                            />
-                        </div>
-                    </>
-                )}
-                {(mode === "save") && (
-                    <>
-                        <div className="popup-body-container">
-                            <h3 className="popup-title">Save {type} to:</h3>
-                            <div className="popup-body-main">
-                                {
-                                    maps.map(map =>
-                                        <p
-                                            className={`popup-save-map-option ${selectedMap && selectedMap.map.eid === map.map.eid && "save-map-highlighted"}`}
-                                            onClick={() => setSelectedMap(map)}
-                                        >
-                                            {map.map.name}
-                                        </p>)
+                    </div>
+                    <div className="popup-sidebar">
+                        <img src={require("../assets/img/icon-cross.svg")}
+                            onClick={() => {
+                                setMode("display");
+                            }}
+                            className="popup-sidebar-button"
+                        />
+                        <img src={require("../assets/img/icon-tick.svg")}
+                            className="popup-sidebar-button"
+                            onClick={() => {
+                                if (selectedMap) {
+                                    addObjectToMap(object, selectedMap);
+                                    setMode("complete");
                                 }
-                            </div>
-                        </div>
-                        <div className="popup-sidebar">
-                            <img src={require("../assets/img/icon-cross.svg")}
-                                onClick={() => {
-                                    setMode("display");
-                                }}
-                                className="popup-sidebar-button"
-                            />
-                            <img src={require("../assets/img/icon-tick.svg")}
-                                className="popup-sidebar-button"
-                                onClick={() => {
-                                    if (selectedMap) {
-                                        addObjectToMap(object, selectedMap);
-                                        setMode("complete");
-                                    }
-                                }}
-                            />
-                        </div>
-                    </>
-                )}
-                {(mode === "complete") && (
-                    <>
-
-                        <p className="popup-save-success-text">
-                            {type.slice(0, 1).toUpperCase() + type.slice(1)} successfully saved to
-                            <br />
-                            '{selectedMap.map.name}'
-                        </p>
-
-                        <div className="popup-sidebar">
-                            <img src={require("../assets/img/icon-tick.svg")}
-                                className="popup-sidebar-button"
-                                onClick={() => {
-                                    closeDescription();
-                                    setMode("display");
-                                }}
-                            />
-                        </div>
-                    </>
-                )}
-            </div>}
+                            }}
+                        />
+                    </div>
+                </>
+            )}
+            {(mode === "complete") && (
+                <>
+                    <p className="popup-save-success-text">
+                        {type.slice(0, 1).toUpperCase() + type.slice(1)} successfully saved to
+                        <br />
+                        '{selectedMap.map.name}'
+                    </p>
+                    <div className="popup-sidebar">
+                        <img src={require("../assets/img/icon-tick.svg")}
+                            className="popup-sidebar-button"
+                            onClick={() => {
+                                closeDescription();
+                                setMode("display");
+                            }}
+                        />
+                    </div>
+                </>
+            )}
         </div>
     );
 }

--- a/src/components/DrawingLayers.js
+++ b/src/components/DrawingLayers.js
@@ -10,7 +10,7 @@ class DrawingLayers extends Component {
             console.log("type", type);
             return (<Drawing
                 type={type}
-                key={polygon.data.id}
+                key={polygon.uuid}
                 polygon={polygon}
                 name={polygon.name}
             />)

--- a/src/components/DrawingPopup.js
+++ b/src/components/DrawingPopup.js
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import axios from "axios/index";
+import constants from "../constants";
+import { getAuthHeader } from "../utils/Auth";
+import { useDispatch, useSelector } from "react-redux";
+
+const DrawingPopup = ({ object, type, closeDescription }) => {
+    const [mode, setMode] = useState("display");
+    const [name, setName] = useState(object.name);
+    const [description, setDescription] = useState(object.description);
+    const saved = useSelector((state) => state.map.name !== null);
+    const dispatch = useDispatch();
+
+    const editObject = async (newName, newDescription) => {
+        dispatch({
+            type: (type === "marker") ? 'RENAME_MARKER' : 'RENAME_POLYGON',
+            payload: {
+                name: newName,
+                description: newDescription,
+                uuid: object.uuid
+            }
+        })
+        if (saved) {
+            // Autosave
+            const body = {
+                name: newName,
+                description: newDescription,
+                object
+            };
+            await axios.post(`${constants.ROOT_URL}/api/user/edit/${type}`, body, getAuthHeader());
+        }
+    }
+
+    return (
+        <div className="popup-content">
+            <div className="popup-close" onClick={closeDescription} />
+            {(mode === "display") && (
+                <>
+                    <div className="popup-body-container">
+                        <h3 className="popup-title">{name}</h3>
+                        <div className="popup-body-main">
+                            <p className="description-text">{description}</p>
+                        </div>
+                    </div>
+                    <div className="popup-sidebar">
+                        <img src={require("../assets/img/icon-pencil.svg")}
+                            className="popup-sidebar-button"
+                            onClick={() => setMode("edit")}
+                        />
+                    </div>
+                </>
+            )}
+            {(mode === "edit") && (
+                <>
+                    <div className="popup-body-container">
+                        <h3 className="popup-title editable" id="popup-name" contentEditable>{name}</h3>
+                        <div className="popup-body-main">
+                            <p className="description-text editable" id="popup-description" contentEditable>{description}</p>
+                        </div>
+                    </div>
+                    <div className="popup-sidebar">
+                        <img src={require("../assets/img/icon-cross.svg")}
+                            onClick={() => {
+                                setName(object.name);
+                                setDescription(object.description);
+                                setMode("display");
+                            }}
+                            className="popup-sidebar-button"
+                        />
+                        <img src={require("../assets/img/icon-tick.svg")}
+                            className="popup-sidebar-button"
+                            onClick={() => {
+                                const newName = document.getElementById("popup-name").textContent;
+                                const newDescription = document.getElementById("popup-description").textContent;
+                                setName(newName);
+                                setDescription(newDescription);
+                                setMode("display");
+                                editObject(newName, newDescription);
+                            }}
+                        />
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+export default DrawingPopup;

--- a/src/components/MapDataGroups.js
+++ b/src/components/MapDataGroups.js
@@ -89,7 +89,7 @@ const MapDataGroups = ({ popupVisible, setPopupVisible }) => {
         dataGroup.markers.forEach((marker) => {
           dataGroupMarkers.push(
             <DataGroupMarker
-              key={marker.idmarkers}
+              key={marker.uuid}
               coordinates={marker.location.coordinates}
               name={marker.name}
               description={marker.description}
@@ -102,6 +102,7 @@ const MapDataGroups = ({ popupVisible, setPopupVisible }) => {
         dataGroup.polygons.forEach((polygon) => {
           dataGroupPolygons.push(
             <DataGroupPolygon
+              key={polygon.uuid}
               polygon={polygon}
               setPopupVisible={setPopupVisible}
               popupVisible={popupVisible}
@@ -112,6 +113,7 @@ const MapDataGroups = ({ popupVisible, setPopupVisible }) => {
         dataGroup.lines.forEach((line) => {
           dataGroupLines.push(
             <DataGroupLine
+              key={line.uuid}
               line={line}
               setPopupVisible={setPopupVisible}
               popupVisible={popupVisible}

--- a/src/components/MarkerPin.js
+++ b/src/components/MarkerPin.js
@@ -1,183 +1,87 @@
 import React, { Component } from 'react';
-import { Marker, Popup } from 'react-mapbox-gl';
+import { Marker } from 'react-mapbox-gl';
 import { connect } from 'react-redux';
+import DrawingPopup from './DrawingPopup';
 
 class MarkerPin extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            editing: false,
-            hidden: false,
+            popupClosed: false,
             input: '',
         }
     }
 
     componentDidUpdate(prevProps) {
-        if ((prevProps.currentMarker === this.props.marker.uuid) && (this.props.currentMarker !== this.props.marker.uuid)) {
-            this.setState({ hidden: false });
+        if (prevProps.active && !this.props.active) {
+            // Reset so that popup opens if we set the marker to active again
+            this.setState({ popupClosed: false });
         }
     }
 
     render() {
-        let { marker, currentMarker, activeTool, readOnly, baseLayer } = this.props;
-        let { hidden, input, editing } = this.state;
-        let active = currentMarker === marker.uuid;
-        let showPopup = active && !activeTool;
-        console.log("active", active);
+        let { marker, active, activeTool, baseLayer } = this.props;
+        let showPopup = !this.state.popupClosed && active && !activeTool;
         return (
-            <div>
-                <Marker
-                    key={marker.uuid}
-                    coordinates={marker.coordinates}
-                    name={marker.name}
-                    description={marker.description}
-                    anchor="bottom"
-                    style={{ height: '40px', zIndex: 1 }}
-                >
-                    <div className={active ? "marker-icon-active" : baseLayer === 'aerial' ? "marker-icon-aerial" : "marker-icon"}
-                        style={{
-                            height: 40,
-                            width: 40,
-                            zIndex: 1
-                        }}
-                        onClick={(evt) => {
-                            if (!activeTool) {
-                                if (marker.uuid === currentMarker) {
-                                    this.props.dispatch({ type: 'CLEAR_CURRENT_MARKER' });
-                                    this.setState({ hidden: false });
-                                } else {
-                                    this.props.dispatch({
-                                        type: 'SET_CURRENT_MARKER',
-                                        payload: marker.uuid
-                                    })
-                                }
-                            }
-                        }}
-                    />
-                </Marker>
-                <Popup
-                    coordinates={marker.coordinates}
-                    offset={{
-                        'bottom': [0, -60]
-                    }}
-                    anchor={"bottom"}
-                    className="drawing-popup"
-                    style={{
-                        display: !hidden && showPopup ? 'block' : 'none',
-                        zIndex: 2
-                    }}
-                >
+            <Marker
+                key={marker.uuid}
+                coordinates={marker.coordinates}
+                name={marker.name}
+                description={marker.description}
+                anchor="bottom"
+                style={{ height: '40px', zIndex: active ? 4 : 3 }}
+            >
+                <div>
                     <div
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            e.preventDefault();
-                        }}
-                        className="drawing-popup-content"
-                    >
-                        {!this.state.editing && (
-                            <div
-                                className="popup-close"
-                                onClick={() => {
-                                    this.setState({ hidden: true })
-                                }}
-                            />
-                        )}
-                        {this.state.editing ? (
-                            <input
-                                type="text"
-                                className="text-input"
-                                style={{
-                                    textAlign: 'center',
-                                    padding: 0
-                                }}
-                                value={this.state.input}
-                                onChange={(e) => {
-                                    this.setState({
-                                        input: e.target.value
-                                    })
-                                }}
-                            />
-                        ) : (
-                            <h2 className="marker-name">{marker.name}</h2>
-                        )}
-                        {
-                            this.state.editing ? (
-                                <div className="popup-buttons">
-                                    <div className="left"
-                                        style={{
-                                            color: 'rgba(208, 2, 78, 0.95)'
-                                        }}
-                                        onClick={() => {
-                                            this.setState({
-                                                editing: !this.state.editing,
-                                                input: null
-                                            });
-                                        }}
-                                    >Cancel
-                                    </div>
-                                    <div className="right"
-                                        style={{
-                                            color: '#2ecc71'
-                                        }}
-                                        onClick={() => {
-                                            if (this.state.input) {
-                                                this.props.dispatch({
-                                                    type: 'RENAME_MARKER',
-                                                    payload: {
-                                                        name: this.state.input,
-                                                        uuid: marker.uuid
-                                                    }
-                                                })
-                                                this.setState({
-                                                    editing: !this.state.editing,
-                                                    input: null
-                                                });
-                                            }
-                                        }}
-                                    >OK
-                                    </div>
-                                </div>
-                            ) : (
-                                <div className="popup-buttons">
-                                    <div className="left"
-                                        onClick={() => {
-                                            this.props.dispatch({
-                                                type: 'OPEN_NAVIGATION',
-                                            })
-                                            this.props.dispatch({
-                                                type: 'SET_ACTIVE',
-                                                payload: 'Land Information'
-                                            })
-                                        }}
-                                    >Info
-                                    </div>
-                                    <div className="right"
-                                        onClick={() => {
-                                            if (!readOnly) {
-                                                this.setState({
-                                                    editing: !this.state.editing,
-                                                    input: marker.name
-                                                });
-                                            }
-                                        }}
-                                    >Rename
-                                    </div>
-                                </div>
-                            )
-                        }
+                        data-tooltip={marker.name}
+                        className="pointer">
+                        <div className={active ? "marker-icon-active" : baseLayer === 'aerial' ? "marker-icon-aerial" : "marker-icon"}
+                            style={{
+                                height: 40,
+                                width: 40,
+                                zIndex: 2,
+                                position: "absolute",
+                                top: '0px',
+                                left: '-20px',
+                            }}
+                            onClick={() => {
+                                if (!activeTool) {
+                                    if (active) {
+                                        this.props.dispatch({ type: 'CLEAR_CURRENT_MARKER' });
+                                        this.setState({ popupClosed: false });
+                                    } else {
+                                        this.props.dispatch({
+                                            type: 'SET_CURRENT_MARKER',
+                                            payload: marker.uuid
+                                        })
+                                    }
+                                }
+                            }}
+                        />
+                        <span className="marker-shadow"></span>
                     </div>
-                </Popup>
-            </div>
+                    {showPopup && (
+                        <div style={{
+                            position: "relative",
+                            bottom: "-5px"
+                        }}>
+                            <DrawingPopup
+                                object={marker}
+                                type={"marker"}
+                                closeDescription={() => this.setState({ popupClosed: true })}
+                            />
+                        </div>
+                    )}
+                </div>
+            </Marker>
         );
     }
 }
 
 MarkerPin.propTypes = {};
 
-const mapStateToProps = ({ markers, navigation, readOnly, mapBaseLayer }) => ({
-    currentMarker: markers.currentMarker,
+const mapStateToProps = ({ navigation, mapBaseLayer }) => ({
     activeTool: navigation.activeTool,
-    readOnly: readOnly.readOnly,
     baseLayer: mapBaseLayer.layer,
 })
 

--- a/src/components/Markers.js
+++ b/src/components/Markers.js
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import MarkerPin from './MarkerPin';
 import { Cluster, Marker } from 'react-mapbox-gl';
 
-const ClusterMarker = (coordinates, pointCount) => {
+const ClusterMarker = (coordinates, pointCount, getLeaves) => {
+    const containsActiveMarker = getLeaves(Infinity).some((marker) => marker.props.active);
     return (
         <Marker
             key={coordinates.toString()}
@@ -12,7 +13,7 @@ const ClusterMarker = (coordinates, pointCount) => {
         >
             <div className="cluster-container cluster-grey-transparent">
                 <div className="cluster-background cluster-grey">
-                    <p className="cluster-text">{pointCount}</p>
+                    <p className={containsActiveMarker ? "cluster-text cluster-text-active" : "cluster-text"}>{pointCount}</p>
                 </div>
             </div>
         </Marker>
@@ -67,7 +68,7 @@ class Markers extends Component {
     }
 
     render() {
-        let { markers, searchMarker, currentLocation } = this.props;
+        let { markers, searchMarker, currentLocation, currentMarker } = this.props;
         console.log("marker map?", this.props.map);
         console.log("search marker", searchMarker);
         let clusterRadius = 60;
@@ -116,6 +117,7 @@ class Markers extends Component {
                                 coordinates={marker.coordinates}
                                 marker={marker}
                                 handleMarkerClick={this.handleMarkerClick}
+                                active={currentMarker === marker.uuid}
                             />
                         ))}
                     </Cluster>
@@ -131,6 +133,7 @@ const mapStateToProps = ({ map, markers }) => ({
     searchMarker: map.searchMarker,
     currentLocation: map.currentLocation,
     markers: markers.markers,
+    currentMarker: markers.currentMarker,
 });
 
 export default connect(mapStateToProps)(Markers);

--- a/src/components/PolygonSection.js
+++ b/src/components/PolygonSection.js
@@ -44,7 +44,7 @@ class PolygonSection extends Component {
     }
     render() {
         let { polygon, activePolygon, dispatch } = this.props;
-        let open = polygon.data.id === activePolygon;
+        let open = polygon.uuid === activePolygon;
         return (
             <div className="nav-tray-section">
                 <div className={`nav-tray-section-title polygon-section${polygon.type === 'Polygon' ? '' : '-line'}`}
@@ -56,7 +56,7 @@ class PolygonSection extends Component {
                         } else {
                             dispatch({
                                 type: 'SET_ACTIVE_POLYGON',
-                                payload: polygon.data.id
+                                payload: polygon.uuid
                             })
                         }
                     }}

--- a/src/components/common/DrawingTool.js
+++ b/src/components/common/DrawingTool.js
@@ -35,7 +35,7 @@ const DrawingTool = ({ tool, name, mode, size, drawControl }) => {
                     // change to the specific drawing mode
                     drawControl.draw.changeMode(mode);
                 }
-            } else {
+            } else if (mode) {
                 // change to the specific drawing mode
                 drawControl.draw.changeMode(mode);
             }

--- a/src/components/common/ToggleSwitch.js
+++ b/src/components/common/ToggleSwitch.js
@@ -21,7 +21,7 @@ class ToggleSwitch extends Component {
                     <input
                         type="checkbox"
                         checked={on}
-                        onChange={this.handleChange}
+                        onChange={e => { }}
                     />
                     <span className="slider round"></span>
                 </label>

--- a/src/reducers/DrawingReducer.js
+++ b/src/reducers/DrawingReducer.js
@@ -21,11 +21,11 @@ export default (state = INITIAL_STATE, action) => {
                 polygons: polygons,
                 polygonsDrawn: action.payload.type === 'Polygon' ? polygonsDrawn + 1 : polygonsDrawn,
                 linesDrawn: action.payload.type === 'LineString' ? linesDrawn + 1 : linesDrawn,
-                activePolygon: action.payload.data.id
+                activePolygon: action.payload.uuid
             };
         case 'UPDATE_POLYGON':
             polygons = state.polygons.map((polygon) => {
-                if (polygon.data.id === action.payload.data.id) {
+                if (polygon.uuid === action.payload.uuid) {
                     return {
                         ...polygon,
                         data: action.payload.data,
@@ -44,7 +44,7 @@ export default (state = INITIAL_STATE, action) => {
             }
         case 'DELETE_POLYGON':
             polygons = state.polygons.filter((polygon) => {
-                if (polygon.data.id === action.payload) {
+                if (polygon.uuid === action.payload) {
                     console.log("delete polygon", polygon);
                     return false;
                 } else {
@@ -58,10 +58,11 @@ export default (state = INITIAL_STATE, action) => {
             }
         case 'RENAME_POLYGON':
             polygons = state.polygons.map((polygon) => {
-                if (polygon.data.id === action.payload.id) {
+                if (polygon.uuid === action.payload.uuid) {
                     return {
                         ...polygon,
-                        name: action.payload.name
+                        name: action.payload.name,
+                        description: action.payload.description,
                     };
                 } else {
                     return polygon;

--- a/src/reducers/MarkersReducer.js
+++ b/src/reducers/MarkersReducer.js
@@ -42,7 +42,8 @@ export default (state = INITIAL_STATE, action) => {
                 if (marker.uuid === action.payload.uuid) {
                     return {
                         ...marker,
-                        name: action.payload.name
+                        name: action.payload.name,
+                        description: action.payload.description,
                     }
                 } else {
                     return marker;

--- a/src/utils/saveMap.js
+++ b/src/utils/saveMap.js
@@ -2,6 +2,7 @@ import axios from "axios/index";
 import constants, { VERSION } from "../constants";
 import { getAuthHeader } from "./Auth";
 
+/** Resave a map without changing any data */
 export const saveExistingMap = async (existingMap) => {
     const { map } = existingMap;
     const { name, eid } = existingMap.map;


### PR DESCRIPTION
#### What? Why?

Closes #123 

Drawn objects have a description field in the database, which isn't currently visible or editable. This change makes the description editable, using similar UX to #126   

#### What should we test?

Open a saved map
Click on a marker/polygon/line
Click edit
change text of name/description
press the tick to save
press the cross to cancel

Do the same for a new map that isn't yet saved
Also, test with some layers enabled to make sure clicking between drawn objects and datagroup objects is as expected

Open the info panel and click on a drawn object. Its popup should appear. If the object is part of a cluster, the number should turn to the active 'green' colour to signal that it is within the popup

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
