### PR TITLE
Add Admin Boundaries Section to Data Layers

### DIFF
--- a/src/components/MapLayers.js
+++ b/src/components/MapLayers.js
@@ -11,7 +11,7 @@ class MapLayers extends Component {
                 <Source
                     tileJsonSource={{
                         "type": "vector",
-                        "url": "mapbox://joolzt.ay7acj73,joolzt.9edhyytu,joolzt.6dd4p92w,joolzt.50odxxr1,joolzt.cpacrvmx,joolzt.c3j1rh4t,joolzt.75llshed,joolzt.4i2tzpgj,kingmob.8cgpa2xi"
+                        "url": "mapbox://joolzt.ay7acj73,joolzt.9edhyytu,joolzt.6dd4p92w,joolzt.50odxxr1,joolzt.cpacrvmx,joolzt.c3j1rh4t,joolzt.75llshed,joolzt.4i2tzpgj,kingmob.8cgpa2xi,joolzt.6s8qdvfi"
                     }}
                     id="composite"
                 />
@@ -201,6 +201,20 @@ class MapLayers extends Component {
                     paint={{
                         "fill-color": "hsla(0, 100%, 0%, 0.8)",
                         "fill-opacity": landDataLayers.indexOf('wards-may-2019-boundaries-uk-d9ukjy') !== -1 ? .4 : 0,
+                    }}
+                />
+                <Layer
+                    id="county-4ef4ik"
+                    type="fill"
+                    sourceId="composite"
+                    sourceLayer="county-4ef4ik"
+                    minZoom={6}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "fill-color": "hsla(113, 97%, 50%, 0.4)",
+                        "fill-opacity": landDataLayers.indexOf('county-4ef4iky') !== -1 ? .4 : 0
                     }}
                 />
             </React.Fragment>

--- a/src/components/MapLayers.js
+++ b/src/components/MapLayers.js
@@ -200,16 +200,17 @@ class MapLayers extends Component {
                 />
                 <Layer
                     id="wards-cu4dni"
-                    type="fill"
+                    type="line"
                     sourceId="wards"
                     sourceLayer="wards-cu4dni"
-                    minZoom={6}
+                    //minZoom={6}
                     layout={{
                         "visibility": "visible"
                     }}
                     paint={{
-                        "fill-color": "hsla(245, 100%, 50%, 0.3)",
-                        "fill-opacity": landDataLayers.indexOf('wards-cu4dni') !== -1 ? 1 : 0,
+                        "line-color": "hsla(245, 100%, 50%, 0.3)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('wards-cu4dni') !== -1 ? 1 : 0,
                     }}
                 />
                 <Source
@@ -221,7 +222,7 @@ class MapLayers extends Component {
                 />
                 <Layer
                     id="county-4ef4ik"
-                    type="fill"
+                    type="line"
                     sourceId="county"
                     sourceLayer="county-4ef4ik"
                     minZoom={6}
@@ -229,8 +230,9 @@ class MapLayers extends Component {
                         "visibility": "visible"
                     }}
                     paint={{
-                        "fill-color": "hsla(113, 97%, 50%, 0.4)",
-                        "fill-opacity": landDataLayers.indexOf('county-4ef4ik') !== -1 ? 1 : 0
+                        "line-color": "hsla(113, 97%, 50%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('county-4ef4ik') !== -1 ? 1 : 0
                     }}
                 />
                 <Source
@@ -242,7 +244,7 @@ class MapLayers extends Component {
                 />
                 <Layer
                     id="westminster_const_region-8r33ph"
-                    type="fill"
+                    type="line"
                     sourceId="constituency"
                     sourceLayer="westminster_const_region-8r33ph"
                     minZoom={6}
@@ -250,29 +252,9 @@ class MapLayers extends Component {
                         "visibility": "visible"
                     }}
                     paint={{
-                        "fill-color": "hsla(183, 97%, 50%, 0.4)",
-                        "fill-opacity": landDataLayers.indexOf('westminster_const_region-8r33ph') !== -1 ? 1 : 0
-                    }}
-                />
-                <Source
-                    tileJsonSource={{
-                        "type": "vector",
-                        "url": "mapbox://joolzt.2d1u9n5a"
-                    }}
-                    id="constituency"
-                />
-                <Layer
-                    id="westminster_const_region-8r33ph"
-                    type="fill"
-                    sourceId="constituency"
-                    sourceLayer="westminster_const_region-8r33ph"
-                    minZoom={6}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "fill-color": "hsla(183, 97%, 50%, 0.4)",
-                        "fill-opacity": landDataLayers.indexOf('westminster_const_region-8r33ph') !== -1 ? 1 : 0
+                        "line-color": "hsla(183, 97%, 50%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('westminster_const_region-8r33ph') !== -1 ? 1 : 0
                     }}
                 />
                 <Source
@@ -284,7 +266,7 @@ class MapLayers extends Component {
                 />
                 <Layer
                     id="district_borough_unitary_regi-bquzqt"
-                    type="fill"
+                    type="line"
                     sourceId="councils"
                     sourceLayer="district_borough_unitary_regi-bquzqt"
                     minZoom={6}
@@ -292,8 +274,113 @@ class MapLayers extends Component {
                         "visibility": "visible"
                     }}
                     paint={{
-                        "fill-color": "hsla(56, 97%, 50%, 0.4)",
-                        "fill-opacity": landDataLayers.indexOf('district_borough_unitary_regi-bquzqt') !== -1 ? 1 : 0
+                        "line-color": "hsla(56, 97%, 50%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('district_borough_unitary_regi-bquzqt') !== -1 ? 1 : 0
+                    }}
+                />
+                <Source
+                    tileJsonSource={{
+                        "type": "vector",
+                        "url": "mapbox://joolzt.6kicmrlr,joolzt.b1kdveqs"
+                    }}
+                    id="devolved-composite"
+                />
+                <Layer
+                    id="greater_london_const_region-aplvbp"
+                    type="line"
+                    sourceId="devolved-composite"
+                    sourceLayer="greater_london_const_region-aplvbp"
+                    minZoom={6}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "line-color": "hsla(320, 97%, 50%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('devolved-powers') !== -1 ? 1 : 0
+                    }}
+                />
+                <Layer
+                    id="scotland_and_wales-8wahad"
+                    type="line"
+                    sourceId="devolved-composite"
+                    sourceLayer="scotland_and_wales-8wahad"
+                    minZoom={6}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "line-color": "hsla(320, 97%, 50%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('devolved-powers') !== -1 ? 1 : 0
+                    }}
+                />
+                <Source
+                    tileJsonSource={{
+                        "type": "vector",
+                        "url": "mapbox://joolzt.cq0hagq5,joolzt.dj4c79tf,joolzt.0bha665k,joolzt.b68bzxbu"
+                    }}
+                    id="parishes-composite"
+                />
+                <Layer
+                    id="parish_1-bcfcla"
+                    type="line"
+                    sourceId="parishes-composite"
+                    sourceLayer="parish_1-bcfcla"
+                    minZoom={9}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "line-color": "hsla(280, 60%, 70%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
+                    }}
+                />
+                <Layer
+                    id="parish_2-c6mbmy"
+                    type="line"
+                    sourceId="parishes-composite"
+                    sourceLayer="parish_2-c6mbmy"
+                    minZoom={9}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "line-color": "hsla(280, 60%, 70%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
+                    }}
+                />
+                <Layer
+                    id="parish_3-chtvqw"
+                    type="line"
+                    sourceId="parishes-composite"
+                    sourceLayer="parish_3-chtvqw"
+                    minZoom={9}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "line-color": "hsla(280, 60%, 70%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
+                    }}
+                />
+                <Layer
+                    id="parish_4-cwfy3j"
+                    type="line"
+                    sourceId="parishes-composite"
+                    sourceLayer="parish_4-cwfy3j"
+                    minZoom={9}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "line-color": "hsla(280, 60%, 70%, 0.4)",
+                        "line-width": 3,
+                        "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
                     }}
                 />
             </React.Fragment>

--- a/src/components/MapLayers.js
+++ b/src/components/MapLayers.js
@@ -1,399 +1,388 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import { Source, Layer } from 'react-mapbox-gl';
 
-class MapLayers extends Component {
-    render() {
-        const { landDataLayers } = this.props;
+const MapLayers = () => {
+    const landDataLayers = useSelector(state => state.mapLayers.landDataLayers);
 
-        console.log(landDataLayers)
-
-        return (
-            <React.Fragment>
-                <Source
-                    tileJsonSource={{
-                        "type": "vector",
-                        "url": "mapbox://joolzt.ay7acj73,joolzt.9edhyytu,joolzt.6dd4p92w,joolzt.50odxxr1,joolzt.cpacrvmx,joolzt.c3j1rh4t,joolzt.75llshed,joolzt.4i2tzpgj,kingmob.8cgpa2xi,"
-                    }}
-                    id="composite"
-                />
-                <Layer
-                    id="provisional-agricultural-land-ab795l"
-                    type="fill"
-                    sourceId="composite"
-                    sourceLayer="Provisional_Agricultural_Land-ab795l"
-                    minZoom={9}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "fill-color": [
-                            "match",
-                            [
-                                "get",
-                                "ALC_GRADE"
-                            ],
-                            "Grade 1",
-                            "#3980d0",
-                            "Grade 2",
-                            "#10c3ef",
-                            "Grade 3",
-                            "#0fb08f",
-                            "Grade 4",
-                            "#f9f90d",
-                            "Grade 5",
-                            "#c9748e",
-                            "Exclusion",
-                            "#b2b2b2",
-                            "Non Agricultural",
-                            "#b2b2b2",
-                            "Urban",
-                            "#b2b2b2",
-                            "hsl(0, 83%, 56%)"
+    return (
+        <React.Fragment>
+            <Source
+                tileJsonSource={{
+                    "type": "vector",
+                    "url": "mapbox://joolzt.ay7acj73,joolzt.9edhyytu,joolzt.6dd4p92w,joolzt.50odxxr1,joolzt.cpacrvmx,joolzt.c3j1rh4t,joolzt.75llshed,joolzt.4i2tzpgj,kingmob.8cgpa2xi,"
+                }}
+                id="composite"
+            />
+            <Layer
+                id="provisional-agricultural-land-ab795l"
+                type="fill"
+                sourceId="composite"
+                sourceLayer="Provisional_Agricultural_Land-ab795l"
+                minZoom={9}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "fill-color": [
+                        "match",
+                        [
+                            "get",
+                            "ALC_GRADE"
                         ],
-                        "fill-opacity": landDataLayers.indexOf('provisional-agricultural-land-ab795l') !== -1 ? .4 : 0,
-                    }}
-                />
-                <Layer
-                    id="national-forest-estate-soil-g-18j2ga"
-                    type="fill"
-                    sourceId="composite"
-                    sourceLayer="NATIONAL_FOREST_ESTATE_SOIL_G-18j2ga"
-                    minZoom={8}
-                    layout={{
-                        "visibility": "visible",
-                    }}
-                    paint={{
-                        "fill-color": [
-                            "match",
-                            [
-                                "get",
-                                "S1_Group"
-                            ],
-                            "Basin Bog",
-                            "#b2b2b2",
-                            "Brown Earth",
-                            "#895c44",
-                            "Calcareous Soil",
-                            "#4de600",
-                            "Eroded Bog",
-                            "#9c9c9c",
-                            "Flat or Raised Bogs",
-                            "#686868",
-                            "Flushed Blanket Bog",
-                            "#333333",
-                            "Ground-water Gley",
-                            "#014ea6",
-                            "Ironpan Soil",
-                            "#fc5601",
-                            "Littoral Soil",
-                            "#fefe67",
-                            "Man-made Soil",
-                            "#ab00e5",
-                            "Peaty Surface-water Gley",
-                            "#0085a8",
-                            "Podzol",
-                            "#e60002",
-                            "Skeletal Soil",
-                            "#e7e600",
-                            "Surface-water Gley",
-                            "#00a8e7",
-                            "Unflushed Blanket Bog",
-                            "#010101",
-                            "Valley Complex",
-                            "#8d8ead",
-                            "#3980d0"
+                        "Grade 1",
+                        "#3980d0",
+                        "Grade 2",
+                        "#10c3ef",
+                        "Grade 3",
+                        "#0fb08f",
+                        "Grade 4",
+                        "#f9f90d",
+                        "Grade 5",
+                        "#c9748e",
+                        "Exclusion",
+                        "#b2b2b2",
+                        "Non Agricultural",
+                        "#b2b2b2",
+                        "Urban",
+                        "#b2b2b2",
+                        "hsl(0, 83%, 56%)"
+                    ],
+                    "fill-opacity": landDataLayers.indexOf('provisional-agricultural-land-ab795l') !== -1 ? .4 : 0,
+                }}
+            />
+            <Layer
+                id="national-forest-estate-soil-g-18j2ga"
+                type="fill"
+                sourceId="composite"
+                sourceLayer="NATIONAL_FOREST_ESTATE_SOIL_G-18j2ga"
+                minZoom={8}
+                layout={{
+                    "visibility": "visible",
+                }}
+                paint={{
+                    "fill-color": [
+                        "match",
+                        [
+                            "get",
+                            "S1_Group"
                         ],
-                        "fill-opacity": landDataLayers.indexOf('national-forest-estate-soil-g-18j2ga') !== -1 ? .4 : 0,
-                    }}
-                />
-                <Layer
-                    id="historic-flood-map-5y05ao"
-                    type="fill"
-                    sourceId="composite"
-                    sourceLayer="Historic_Flood_Map-5y05ao"
-                    minZoom={8}
-                    layout={{
-                        "visibility": "visible",
-                    }}
-                    paint={{
-                        "fill-color": "hsl(196, 80%, 70%)",
-                        "fill-opacity": landDataLayers.indexOf('historic-flood-map-5y05ao') !== -1 ? .4 : 0,
-                    }}
-                />
-                <Layer
-                    id="sites-of-special-scientific-i-09kaq4"
-                    type="fill"
-                    sourceId="composite"
-                    sourceLayer="Sites_of_Special_Scientific_I-09kaq4"
-                    minZoom={8}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "fill-color": "hsl(1, 40%, 40%)",
-                        "fill-opacity": landDataLayers.indexOf('sites-of-special-scientific-i-09kaq4') !== -1 ? .4 : 0,
-                    }}
-                />
-                <Layer
-                    id="special-protection-areas-engl-71pdjg"
-                    type="fill"
-                    sourceId="composite"
-                    sourceLayer="Special_Protection_Areas_Engl-71pdjg"
-                    minZoom={8}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "fill-color": "hsl(51, 40%, 40%)",
-                        "fill-opacity": landDataLayers.indexOf('special-protection-areas-engl-71pdjg') !== -1 ? .4 : 0,
-                    }}
-                />
-                <Layer
-                    id="special-areas-of-conservation-bm41zr"
-                    type="fill"
-                    sourceId="composite"
-                    sourceLayer="Special_Areas_of_Conservation-bm41zr"
-                    minZoom={8}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "fill-color": "hsl(101, 40%, 40%)",
-                        "fill-opacity": landDataLayers.indexOf('special-areas-of-conservation-bm41zr') !== -1 ? .4 : 0,
-                    }}
-                />
-                <Layer
-                    id="local-authority-greenbelt-bou-9r44t6"
-                    type="fill"
-                    sourceId="composite"
-                    sourceLayer="Local_Authority_Greenbelt_bou-9r44t6"
-                    minZoom={8}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "fill-color": "hsla(113, 97%, 50%, 0.4)",
-                        "fill-opacity": landDataLayers.indexOf('local-authority-greenbelt-bou-9r44t6') !== -1 ? .4 : 0,
-                    }}
-                />
-                <Layer
-                    id="ncc-brownfield-sites"
-                    type="fill"
-                    sourceId="composite"
-                    sourceLayer="NCC_Brownfield_Sites"
-                    minZoom={8}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "fill-color": "hsla(0, 24%, 20%, 0.5)",
-                        "fill-opacity": landDataLayers.indexOf('ncc-brownfield-sites') !== -1 ? .4 : 0,
-                    }}
-                />
-                <Source
-                    tileJsonSource={{
-                        "type": "vector",
-                        "url": "mapbox://joolzt.25vn26he"
-                    }}
-                    id="wards"
-                />
-                <Layer
-                    id="wards-cu4dni"
-                    type="line"
-                    sourceId="wards"
-                    sourceLayer="wards-cu4dni"
-                    //minZoom={6}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(245, 100%, 50%, 0.3)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('wards-cu4dni') !== -1 ? 1 : 0,
-                    }}
-                />
-                <Source
-                    tileJsonSource={{
-                        "type": "vector",
-                        "url": "mapbox://joolzt.6s8qdvfi"
-                    }}
-                    id="county"
-                />
-                <Layer
-                    id="county-4ef4ik"
-                    type="line"
-                    sourceId="county"
-                    sourceLayer="county-4ef4ik"
-                    minZoom={6}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(113, 97%, 50%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('county-4ef4ik') !== -1 ? 1 : 0
-                    }}
-                />
-                <Source
-                    tileJsonSource={{
-                        "type": "vector",
-                        "url": "mapbox://joolzt.2d1u9n5a"
-                    }}
-                    id="constituency"
-                />
-                <Layer
-                    id="westminster_const_region-8r33ph"
-                    type="line"
-                    sourceId="constituency"
-                    sourceLayer="westminster_const_region-8r33ph"
-                    minZoom={6}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(183, 97%, 50%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('westminster_const_region-8r33ph') !== -1 ? 1 : 0
-                    }}
-                />
-                <Source
-                    tileJsonSource={{
-                        "type": "vector",
-                        "url": "mapbox://joolzt.c5ulw4oz"
-                    }}
-                    id="councils"
-                />
-                <Layer
-                    id="district_borough_unitary_regi-bquzqt"
-                    type="line"
-                    sourceId="councils"
-                    sourceLayer="district_borough_unitary_regi-bquzqt"
-                    minZoom={6}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(56, 97%, 50%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('district_borough_unitary_regi-bquzqt') !== -1 ? 1 : 0
-                    }}
-                />
-                <Source
-                    tileJsonSource={{
-                        "type": "vector",
-                        "url": "mapbox://joolzt.6kicmrlr,joolzt.b1kdveqs"
-                    }}
-                    id="devolved-composite"
-                />
-                <Layer
-                    id="greater_london_const_region-aplvbp"
-                    type="line"
-                    sourceId="devolved-composite"
-                    sourceLayer="greater_london_const_region-aplvbp"
-                    minZoom={6}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(320, 97%, 50%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('devolved-powers') !== -1 ? 1 : 0
-                    }}
-                />
-                <Layer
-                    id="scotland_and_wales-8wahad"
-                    type="line"
-                    sourceId="devolved-composite"
-                    sourceLayer="scotland_and_wales-8wahad"
-                    minZoom={6}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(320, 97%, 50%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('devolved-powers') !== -1 ? 1 : 0
-                    }}
-                />
-                <Source
-                    tileJsonSource={{
-                        "type": "vector",
-                        "url": "mapbox://joolzt.cq0hagq5,joolzt.dj4c79tf,joolzt.0bha665k,joolzt.b68bzxbu"
-                    }}
-                    id="parishes-composite"
-                />
-                <Layer
-                    id="parish_1-bcfcla"
-                    type="line"
-                    sourceId="parishes-composite"
-                    sourceLayer="parish_1-bcfcla"
-                    minZoom={9}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(280, 60%, 70%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
-                    }}
-                />
-                <Layer
-                    id="parish_2-c6mbmy"
-                    type="line"
-                    sourceId="parishes-composite"
-                    sourceLayer="parish_2-c6mbmy"
-                    minZoom={9}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(280, 60%, 70%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
-                    }}
-                />
-                <Layer
-                    id="parish_3-chtvqw"
-                    type="line"
-                    sourceId="parishes-composite"
-                    sourceLayer="parish_3-chtvqw"
-                    minZoom={9}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(280, 60%, 70%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
-                    }}
-                />
-                <Layer
-                    id="parish_4-cwfy3j"
-                    type="line"
-                    sourceId="parishes-composite"
-                    sourceLayer="parish_4-cwfy3j"
-                    minZoom={9}
-                    layout={{
-                        "visibility": "visible"
-                    }}
-                    paint={{
-                        "line-color": "hsla(280, 60%, 70%, 0.4)",
-                        "line-width": 3,
-                        "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
-                    }}
-                />
-            </React.Fragment>
-        );
-    }
+                        "Basin Bog",
+                        "#b2b2b2",
+                        "Brown Earth",
+                        "#895c44",
+                        "Calcareous Soil",
+                        "#4de600",
+                        "Eroded Bog",
+                        "#9c9c9c",
+                        "Flat or Raised Bogs",
+                        "#686868",
+                        "Flushed Blanket Bog",
+                        "#333333",
+                        "Ground-water Gley",
+                        "#014ea6",
+                        "Ironpan Soil",
+                        "#fc5601",
+                        "Littoral Soil",
+                        "#fefe67",
+                        "Man-made Soil",
+                        "#ab00e5",
+                        "Peaty Surface-water Gley",
+                        "#0085a8",
+                        "Podzol",
+                        "#e60002",
+                        "Skeletal Soil",
+                        "#e7e600",
+                        "Surface-water Gley",
+                        "#00a8e7",
+                        "Unflushed Blanket Bog",
+                        "#010101",
+                        "Valley Complex",
+                        "#8d8ead",
+                        "#3980d0"
+                    ],
+                    "fill-opacity": landDataLayers.indexOf('national-forest-estate-soil-g-18j2ga') !== -1 ? .4 : 0,
+                }}
+            />
+            <Layer
+                id="historic-flood-map-5y05ao"
+                type="fill"
+                sourceId="composite"
+                sourceLayer="Historic_Flood_Map-5y05ao"
+                minZoom={8}
+                layout={{
+                    "visibility": "visible",
+                }}
+                paint={{
+                    "fill-color": "hsl(196, 80%, 70%)",
+                    "fill-opacity": landDataLayers.indexOf('historic-flood-map-5y05ao') !== -1 ? .4 : 0,
+                }}
+            />
+            <Layer
+                id="sites-of-special-scientific-i-09kaq4"
+                type="fill"
+                sourceId="composite"
+                sourceLayer="Sites_of_Special_Scientific_I-09kaq4"
+                minZoom={8}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "fill-color": "hsl(1, 40%, 40%)",
+                    "fill-opacity": landDataLayers.indexOf('sites-of-special-scientific-i-09kaq4') !== -1 ? .4 : 0,
+                }}
+            />
+            <Layer
+                id="special-protection-areas-engl-71pdjg"
+                type="fill"
+                sourceId="composite"
+                sourceLayer="Special_Protection_Areas_Engl-71pdjg"
+                minZoom={8}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "fill-color": "hsl(51, 40%, 40%)",
+                    "fill-opacity": landDataLayers.indexOf('special-protection-areas-engl-71pdjg') !== -1 ? .4 : 0,
+                }}
+            />
+            <Layer
+                id="special-areas-of-conservation-bm41zr"
+                type="fill"
+                sourceId="composite"
+                sourceLayer="Special_Areas_of_Conservation-bm41zr"
+                minZoom={8}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "fill-color": "hsl(101, 40%, 40%)",
+                    "fill-opacity": landDataLayers.indexOf('special-areas-of-conservation-bm41zr') !== -1 ? .4 : 0,
+                }}
+            />
+            <Layer
+                id="local-authority-greenbelt-bou-9r44t6"
+                type="fill"
+                sourceId="composite"
+                sourceLayer="Local_Authority_Greenbelt_bou-9r44t6"
+                minZoom={8}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "fill-color": "hsla(113, 97%, 50%, 0.4)",
+                    "fill-opacity": landDataLayers.indexOf('local-authority-greenbelt-bou-9r44t6') !== -1 ? .4 : 0,
+                }}
+            />
+            <Layer
+                id="ncc-brownfield-sites"
+                type="fill"
+                sourceId="composite"
+                sourceLayer="NCC_Brownfield_Sites"
+                minZoom={8}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "fill-color": "hsla(0, 24%, 20%, 0.5)",
+                    "fill-opacity": landDataLayers.indexOf('ncc-brownfield-sites') !== -1 ? .4 : 0,
+                }}
+            />
+            <Source
+                tileJsonSource={{
+                    "type": "vector",
+                    "url": "mapbox://joolzt.25vn26he"
+                }}
+                id="wards"
+            />
+            <Layer
+                id="wards-cu4dni"
+                type="line"
+                sourceId="wards"
+                sourceLayer="wards-cu4dni"
+                //minZoom={6}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(245, 100%, 50%, 0.3)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('wards-cu4dni') !== -1 ? 1 : 0,
+                }}
+            />
+            <Source
+                tileJsonSource={{
+                    "type": "vector",
+                    "url": "mapbox://joolzt.6s8qdvfi"
+                }}
+                id="county"
+            />
+            <Layer
+                id="county-4ef4ik"
+                type="line"
+                sourceId="county"
+                sourceLayer="county-4ef4ik"
+                minZoom={6}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(113, 97%, 50%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('county-4ef4ik') !== -1 ? 1 : 0
+                }}
+            />
+            <Source
+                tileJsonSource={{
+                    "type": "vector",
+                    "url": "mapbox://joolzt.2d1u9n5a"
+                }}
+                id="constituency"
+            />
+            <Layer
+                id="westminster_const_region-8r33ph"
+                type="line"
+                sourceId="constituency"
+                sourceLayer="westminster_const_region-8r33ph"
+                minZoom={6}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(183, 97%, 50%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('westminster_const_region-8r33ph') !== -1 ? 1 : 0
+                }}
+            />
+            <Source
+                tileJsonSource={{
+                    "type": "vector",
+                    "url": "mapbox://joolzt.c5ulw4oz"
+                }}
+                id="councils"
+            />
+            <Layer
+                id="district_borough_unitary_regi-bquzqt"
+                type="line"
+                sourceId="councils"
+                sourceLayer="district_borough_unitary_regi-bquzqt"
+                minZoom={6}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(56, 97%, 50%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('district_borough_unitary_regi-bquzqt') !== -1 ? 1 : 0
+                }}
+            />
+            <Source
+                tileJsonSource={{
+                    "type": "vector",
+                    "url": "mapbox://joolzt.6kicmrlr,joolzt.b1kdveqs"
+                }}
+                id="devolved-composite"
+            />
+            <Layer
+                id="greater_london_const_region-aplvbp"
+                type="line"
+                sourceId="devolved-composite"
+                sourceLayer="greater_london_const_region-aplvbp"
+                minZoom={6}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(320, 97%, 50%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('devolved-powers') !== -1 ? 1 : 0
+                }}
+            />
+            <Layer
+                id="scotland_and_wales-8wahad"
+                type="line"
+                sourceId="devolved-composite"
+                sourceLayer="scotland_and_wales-8wahad"
+                minZoom={6}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(320, 97%, 50%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('devolved-powers') !== -1 ? 1 : 0
+                }}
+            />
+            <Source
+                tileJsonSource={{
+                    "type": "vector",
+                    "url": "mapbox://joolzt.cq0hagq5,joolzt.dj4c79tf,joolzt.0bha665k,joolzt.b68bzxbu"
+                }}
+                id="parishes-composite"
+            />
+            <Layer
+                id="parish_1-bcfcla"
+                type="line"
+                sourceId="parishes-composite"
+                sourceLayer="parish_1-bcfcla"
+                minZoom={9}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(280, 60%, 70%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
+                }}
+            />
+            <Layer
+                id="parish_2-c6mbmy"
+                type="line"
+                sourceId="parishes-composite"
+                sourceLayer="parish_2-c6mbmy"
+                minZoom={9}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(280, 60%, 70%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
+                }}
+            />
+            <Layer
+                id="parish_3-chtvqw"
+                type="line"
+                sourceId="parishes-composite"
+                sourceLayer="parish_3-chtvqw"
+                minZoom={9}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(280, 60%, 70%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
+                }}
+            />
+            <Layer
+                id="parish_4-cwfy3j"
+                type="line"
+                sourceId="parishes-composite"
+                sourceLayer="parish_4-cwfy3j"
+                minZoom={9}
+                layout={{
+                    "visibility": "visible"
+                }}
+                paint={{
+                    "line-color": "hsla(280, 60%, 70%, 0.4)",
+                    "line-width": 3,
+                    "line-opacity": landDataLayers.indexOf('parish') !== -1 ? 1 : 0
+                }}
+            />
+        </React.Fragment>
+    );
 }
 
-MapLayers.propTypes = {
 
-};
-
-const mapStateToProps = ({ mapLayers }) => ({
-    landDataLayers: mapLayers.landDataLayers,
-});
-
-export default connect(mapStateToProps)(MapLayers);
+export default MapLayers;

--- a/src/components/MapLayers.js
+++ b/src/components/MapLayers.js
@@ -4,14 +4,16 @@ import { Source, Layer } from 'react-mapbox-gl';
 
 class MapLayers extends Component {
     render() {
-        let { landDataLayers } = this.props;
+        const { landDataLayers } = this.props;
+
+        console.log(landDataLayers)
 
         return (
             <React.Fragment>
                 <Source
                     tileJsonSource={{
                         "type": "vector",
-                        "url": "mapbox://joolzt.ay7acj73,joolzt.9edhyytu,joolzt.6dd4p92w,joolzt.50odxxr1,joolzt.cpacrvmx,joolzt.c3j1rh4t,joolzt.75llshed,joolzt.4i2tzpgj,kingmob.8cgpa2xi,joolzt.6s8qdvfi"
+                        "url": "mapbox://joolzt.ay7acj73,joolzt.9edhyytu,joolzt.6dd4p92w,joolzt.50odxxr1,joolzt.cpacrvmx,joolzt.c3j1rh4t,joolzt.75llshed,joolzt.4i2tzpgj,kingmob.8cgpa2xi,"
                     }}
                     id="composite"
                 />
@@ -189,24 +191,38 @@ class MapLayers extends Component {
                         "fill-opacity": landDataLayers.indexOf('ncc-brownfield-sites') !== -1 ? .4 : 0,
                     }}
                 />
+                <Source
+                    tileJsonSource={{
+                        "type": "vector",
+                        "url": "mapbox://joolzt.25vn26he"
+                    }}
+                    id="wards"
+                />
                 <Layer
-                    id="wards-may-2019-boundaries-uk-d9ukjy"
+                    id="wards-cu4dni"
                     type="fill"
-                    sourceId="composite"
-                    sourceLayer="Wards_May_2019_Boundaries_UK_-d9ukjy"
-                    minZoom={9}
+                    sourceId="wards"
+                    sourceLayer="wards-cu4dni"
+                    minZoom={6}
                     layout={{
                         "visibility": "visible"
                     }}
                     paint={{
-                        "fill-color": "hsla(0, 100%, 0%, 0.8)",
-                        "fill-opacity": landDataLayers.indexOf('wards-may-2019-boundaries-uk-d9ukjy') !== -1 ? .4 : 0,
+                        "fill-color": "hsla(245, 100%, 50%, 0.3)",
+                        "fill-opacity": landDataLayers.indexOf('wards-cu4dni') !== -1 ? 1 : 0,
                     }}
+                />
+                <Source
+                    tileJsonSource={{
+                        "type": "vector",
+                        "url": "mapbox://joolzt.6s8qdvfi"
+                    }}
+                    id="county"
                 />
                 <Layer
                     id="county-4ef4ik"
                     type="fill"
-                    sourceId="composite"
+                    sourceId="county"
                     sourceLayer="county-4ef4ik"
                     minZoom={6}
                     layout={{
@@ -214,7 +230,70 @@ class MapLayers extends Component {
                     }}
                     paint={{
                         "fill-color": "hsla(113, 97%, 50%, 0.4)",
-                        "fill-opacity": landDataLayers.indexOf('county-4ef4iky') !== -1 ? .4 : 0
+                        "fill-opacity": landDataLayers.indexOf('county-4ef4ik') !== -1 ? 1 : 0
+                    }}
+                />
+                <Source
+                    tileJsonSource={{
+                        "type": "vector",
+                        "url": "mapbox://joolzt.2d1u9n5a"
+                    }}
+                    id="constituency"
+                />
+                <Layer
+                    id="westminster_const_region-8r33ph"
+                    type="fill"
+                    sourceId="constituency"
+                    sourceLayer="westminster_const_region-8r33ph"
+                    minZoom={6}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "fill-color": "hsla(183, 97%, 50%, 0.4)",
+                        "fill-opacity": landDataLayers.indexOf('westminster_const_region-8r33ph') !== -1 ? 1 : 0
+                    }}
+                />
+                <Source
+                    tileJsonSource={{
+                        "type": "vector",
+                        "url": "mapbox://joolzt.2d1u9n5a"
+                    }}
+                    id="constituency"
+                />
+                <Layer
+                    id="westminster_const_region-8r33ph"
+                    type="fill"
+                    sourceId="constituency"
+                    sourceLayer="westminster_const_region-8r33ph"
+                    minZoom={6}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "fill-color": "hsla(183, 97%, 50%, 0.4)",
+                        "fill-opacity": landDataLayers.indexOf('westminster_const_region-8r33ph') !== -1 ? 1 : 0
+                    }}
+                />
+                <Source
+                    tileJsonSource={{
+                        "type": "vector",
+                        "url": "mapbox://joolzt.c5ulw4oz"
+                    }}
+                    id="councils"
+                />
+                <Layer
+                    id="district_borough_unitary_regi-bquzqt"
+                    type="fill"
+                    sourceId="councils"
+                    sourceLayer="district_borough_unitary_regi-bquzqt"
+                    minZoom={6}
+                    layout={{
+                        "visibility": "visible"
+                    }}
+                    paint={{
+                        "fill-color": "hsla(56, 97%, 50%, 0.4)",
+                        "fill-opacity": landDataLayers.indexOf('district_borough_unitary_regi-bquzqt') !== -1 ? 1 : 0
                     }}
                 />
             </React.Fragment>

--- a/src/components/MenuKey.js
+++ b/src/components/MenuKey.js
@@ -80,7 +80,7 @@ class MenuKey extends Component {
             "wards-cu4dni": {
                 name: "Wards",
                 data: {
-                    "Wards": "hsl(0, 100%, 0%)"
+                    "Wards": "hsl(245, 100%, 50%)"
                 }
             },
             "county-4ef4ik": {
@@ -92,13 +92,25 @@ class MenuKey extends Component {
             "westminster_const_region-8r33ph": {
                 name: "Westminster Constituencies",
                 data: {
-                    "Constituencies": "hsl(0, 100%, 0%)"
+                    "Constituencies": "hsl(183, 97%, 50%)"
                 }
             },
             "district_borough_unitary_regi-bquzqt": {
                 name: "Councils",
                 data: {
                     "Councils": "hsl(56, 97%, 50%)"
+                }
+            },
+            "parish": {
+                name: "Parishes",
+                data: {
+                    "Parish": "hsl(280,60%,70%)"
+                }
+            },
+            "devolved-powers": {
+                name: "Devolved Powers",
+                data: {
+                    "Devolved Powers": "hsl(320,97%,50%)"
                 }
             }
         }

--- a/src/components/MenuKey.js
+++ b/src/components/MenuKey.js
@@ -77,7 +77,7 @@ class MenuKey extends Component {
                     "Greenbelt": "hsla(113, 97%, 50%, 0.4)"
                 }
             },
-            "wards-may-2019-boundaries-uk-d9ukjy": {
+            "wards-cu4dni": {
                 name: "Wards",
                 data: {
                     "Wards": "hsl(0, 100%, 0%)"
@@ -87,6 +87,18 @@ class MenuKey extends Component {
                 name: "Counties",
                 data: {
                     "Counties": "hsla(113, 97%, 50%, 0.4)"
+                }
+            },
+            "westminster_const_region-8r33ph": {
+                name: "Westminster Constituencies",
+                data: {
+                    "Constituencies": "hsl(0, 100%, 0%)"
+                }
+            },
+            "district_borough_unitary_regi-bquzqt": {
+                name: "Councils",
+                data: {
+                    "Councils": "hsl(56, 97%, 50%)"
                 }
             }
         }

--- a/src/components/MenuKey.js
+++ b/src/components/MenuKey.js
@@ -83,6 +83,12 @@ class MenuKey extends Component {
                     "Wards": "hsl(0, 100%, 0%)"
                 }
             },
+            "county-4ef4ik": {
+                name: "Counties",
+                data: {
+                    "Counties": "hsla(113, 97%, 50%, 0.4)"
+                }
+            }
         }
     }
 

--- a/src/components/NavLandData.js
+++ b/src/components/NavLandData.js
@@ -72,6 +72,9 @@ const NavLandData = ({ open, active, onClose }) => {
                     onToggle={() => dispatch({ type: "TOGGLE_PROPERTY_DISPLAY" })}
                 />
             </DataLayersContainer>
+            <DataLayersContainer title={"Administrative Boundaries"}>
+                <NavTrayItem draggable={false} title="Counties" layerId='county-4ef4ik' />
+            </DataLayersContainer>
             {userGroupTitlesAndIDs && userGroupTitlesAndIDs.map(userGroup =>
                 <DataLayersContainer title={userGroup.title} key={userGroup.id}>
                     {dataGroupTitlesAndIDs && dataGroupTitlesAndIDs.filter(dataGroup => dataGroup.userGroupId == userGroup.id).map(dataGroup =>

--- a/src/components/NavLandData.js
+++ b/src/components/NavLandData.js
@@ -73,10 +73,12 @@ const NavLandData = ({ open, active, onClose }) => {
                 />
             </DataLayersContainer>
             <DataLayersContainer title={"Administrative Boundaries"}>
-                <NavTrayItem draggable={false} title="Counties" layerId='county-4ef4ik' />
                 <NavTrayItem draggable={false} title="Wards" layerId='wards-cu4dni' />
-                <NavTrayItem draggable={false} title="Constituencies" layerId='westminster_const_region-8r33ph' />
-                <NavTrayItem draggable={false} title="Councils" layerId='district_borough_unitary_regi-bquzqt' />
+                <NavTrayItem draggable={false} title="Parishes" layerId='parish' />
+                <NavTrayItem draggable={false} title="Local Councils" layerId='district_borough_unitary_regi-bquzqt' />
+                <NavTrayItem draggable={false} title="Parliamentary Constituencies" layerId='westminster_const_region-8r33ph' />
+                <NavTrayItem draggable={false} title="Devolved Powers" layerId='devolved-powers' />
+                <NavTrayItem draggable={false} title="Counties" layerId='county-4ef4ik' />
             </DataLayersContainer>
             {userGroupTitlesAndIDs && userGroupTitlesAndIDs.map(userGroup =>
                 <DataLayersContainer title={userGroup.title} key={userGroup.id}>

--- a/src/components/NavLandData.js
+++ b/src/components/NavLandData.js
@@ -74,6 +74,9 @@ const NavLandData = ({ open, active, onClose }) => {
             </DataLayersContainer>
             <DataLayersContainer title={"Administrative Boundaries"}>
                 <NavTrayItem draggable={false} title="Counties" layerId='county-4ef4ik' />
+                <NavTrayItem draggable={false} title="Wards" layerId='wards-cu4dni' />
+                <NavTrayItem draggable={false} title="Constituencies" layerId='westminster_const_region-8r33ph' />
+                <NavTrayItem draggable={false} title="Councils" layerId='district_borough_unitary_regi-bquzqt' />
             </DataLayersContainer>
             {userGroupTitlesAndIDs && userGroupTitlesAndIDs.map(userGroup =>
                 <DataLayersContainer title={userGroup.title} key={userGroup.id}>


### PR DESCRIPTION
#### What? Why?

Closes #170 

Connects to uploaded tilesets on mapbox to provide new overlays showing administrative boundaries


#### What should we test?

Select the data layers section
scroll to administrative boundaries
toggle the various new layers

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

Nope



