### PR TITLE
Remove trailing slashes from API routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "land-map-app",
   "version": "0.1.0",
   "private": true,
-  "homepage": "/app/",
+  "homepage": "/app",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",

--- a/src/actions/MapActions.js
+++ b/src/actions/MapActions.js
@@ -4,7 +4,7 @@ import { getAuthHeader } from "../utils/Auth";
 
 export const getMyMaps = () => {
     return async dispatch => {
-        const response = await axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader());
+        const response = await axios.get(`${constants.ROOT_URL}/api/user/maps`, getAuthHeader());
         console.log("Got maps, response", response);
 
         return dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
@@ -82,7 +82,7 @@ export const saveCurrentMap = (copy = false, snapshot = false, name = undefined)
             "isSnapshot": snapshot || getState().mapMeta.isSnapshot
         };
 
-        return await axios.post(`${constants.ROOT_URL}/api/user/map/save/`, body, getAuthHeader());
+        return await axios.post(`${constants.ROOT_URL}/api/user/map/save`, body, getAuthHeader());
     }
 }
 

--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -4,7 +4,7 @@ import { getAuthHeader } from "../utils/Auth";
 
 export const getUserDetails = () => {
     return dispatch => {
-        axios.get(`${constants.ROOT_URL}/api/user/details/`, getAuthHeader())
+        axios.get(`${constants.ROOT_URL}/api/user/details`, getAuthHeader())
             .then((response) => {
                 if (response.status === 200) {
                     if (response.status === 200) {

--- a/src/components/MapCommunityAssets.js
+++ b/src/components/MapCommunityAssets.js
@@ -29,7 +29,7 @@ class MapCommunityAssets extends Component {
 
     axios
       .post(
-        `${constants.ROOT_URL}/api/council/markers/all/`,
+        `${constants.ROOT_URL}/api/council/markers/all`,
         {},
         getAuthHeader()
       )

--- a/src/components/MapProperties.js
+++ b/src/components/MapProperties.js
@@ -25,7 +25,7 @@ const MapProperties = ({ center, map }) => {
 
     const response = await axios
       .get(
-        `${constants.ROOT_URL}/api/ownership/?sw_lng=` +
+        `${constants.ROOT_URL}/api/ownership?sw_lng=` +
         mapBoundaries._sw.lng +
         "&sw_lat=" +
         mapBoundaries._sw.lat +

--- a/src/components/NavCommunityAssets.js
+++ b/src/components/NavCommunityAssets.js
@@ -117,7 +117,7 @@ class NavCommunityAssets extends Component {
       preConfirm: () => {
         return axios
           .post(
-            `${constants.ROOT_URL}/api/council/upload/replace/`,
+            `${constants.ROOT_URL}/api/council/upload/replace`,
             formData,
             getAuthHeader()
           )
@@ -153,7 +153,7 @@ class NavCommunityAssets extends Component {
   submitForm(data, setResponse) {
     axios
       .post(
-        `${constants.ROOT_URL}/api/council/upload/replace/`,
+        `${constants.ROOT_URL}/api/council/upload/replace`,
         data,
         getAuthHeader()
       )

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -21,7 +21,7 @@ const Navbar = ({ limited }) => {
     <div>
       <div className="navbar-shadow"></div>
       <div className="navbar">
-        <Link to="/app/">
+        <Link to="/app">
           <div className="logo">
           </div>
         </Link>
@@ -54,7 +54,7 @@ const Navbar = ({ limited }) => {
     <div>
       <div className="navbar-shadow"></div>
       <div className="navbar">
-        <Link to="/app/">
+        <Link to="/app">
           <div className="big-logo"></div>
         </Link>
         <div className="navbar-right">

--- a/src/components/common/MultipleNodal.js
+++ b/src/components/common/MultipleNodal.js
@@ -96,7 +96,7 @@ class MultipleNodal extends Component {
       preConfirm: () => {
         axios
           .post(
-            `${constants.ROOT_URL}/api/council/markers/delete/`,
+            `${constants.ROOT_URL}/api/council/markers/delete`,
             {
               id: this.props.id
             },
@@ -222,7 +222,7 @@ class MultipleNodal extends Component {
       preConfirm: () => {
         axios
           .post(
-            `${constants.ROOT_URL}/api/council/markers/update/`,
+            `${constants.ROOT_URL}/api/council/markers/update`,
             {
               id: this.props.id,
               name: document.getElementById("nameForm").value,

--- a/src/components/common/Nodal.js
+++ b/src/components/common/Nodal.js
@@ -90,7 +90,7 @@ class Nodal extends Component {
       preConfirm: () => {
         axios
           .post(
-            `${constants.ROOT_URL}/api/council/markers/delete/`,
+            `${constants.ROOT_URL}/api/council/markers/delete`,
             {
               id: this.props.id
             },
@@ -243,7 +243,7 @@ class Nodal extends Component {
         } else {
           // axios
           //   .post(
-          //     `${constants.ROOT_URL}/api/council/markers/update/`,
+          //     `${constants.ROOT_URL}/api/council/markers/update`,
           //     {
           //       id: this.props.id,
           //       name: document.getElementById("nameForm").value,

--- a/src/components/modals/EmailShare.js
+++ b/src/components/modals/EmailShare.js
@@ -66,11 +66,11 @@ const EmailShare = () => {
             "eid": id,
             "emailAddresses": newEmails
         };
-        axios.post(`${constants.ROOT_URL}/api/user/map/share/sync/`, shareData, getAuthHeader())
+        axios.post(`${constants.ROOT_URL}/api/user/map/share/sync`, shareData, getAuthHeader())
             .then((response) => {
                 if (response.status === 200) {
                     closeModal();
-                    axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+                    axios.get(`${constants.ROOT_URL}/api/user/maps`, getAuthHeader())
                         .then((response) => {
                             console.log("maps response", response);
                             dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data })

--- a/src/components/modals/MyMaps.js
+++ b/src/components/modals/MyMaps.js
@@ -23,7 +23,7 @@ export const MyMaps = ({ stage, setStage, drawControl, redrawPolygons, closeModa
     }
 
     const deleteMap = () => {
-        axios.post(`${constants.ROOT_URL}/api/user/map/delete/`, {
+        axios.post(`${constants.ROOT_URL}/api/user/map/delete`, {
             "eid": active.id
         }, getAuthHeader())
             .then((response) => {
@@ -34,7 +34,7 @@ export const MyMaps = ({ stage, setStage, drawControl, redrawPolygons, closeModa
                         dispatch({ type: 'CHANGE_MOVING_METHOD', payload: 'flyTo' })
                     });
                 }
-                axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+                axios.get(`${constants.ROOT_URL}/api/user/maps`, getAuthHeader())
                     .then((response) => {
                         dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
                         setStage("list");
@@ -124,7 +124,7 @@ export const MyMaps = ({ stage, setStage, drawControl, redrawPolygons, closeModa
                     console.log("Open saved map", savedMap);
                     if (savedMap) {
                         drawControl.draw.deleteAll();
-                        axios.post(`${constants.ROOT_URL}/api/user/map/view/`, {
+                        axios.post(`${constants.ROOT_URL}/api/user/map/view`, {
                             "eid": active.id,
                         }, getAuthHeader())
                         //pick up the old name for the landDataLayers

--- a/src/components/modals/MySharedMaps.js
+++ b/src/components/modals/MySharedMaps.js
@@ -59,7 +59,7 @@ export const MySharedMaps = ({ stage, setStage, drawControl, redrawPolygons, clo
                         console.log("saved map", savedMap);
                         if (savedMap) {
                             drawControl.draw.deleteAll();
-                            axios.post(`${constants.ROOT_URL}/api/user/map/view/`, {
+                            axios.post(`${constants.ROOT_URL}/api/user/map/view`, {
                                 "eid": active.id,
                             }, getAuthHeader());
 

--- a/src/components/modals/Save.js
+++ b/src/components/modals/Save.js
@@ -54,9 +54,9 @@ class Save extends Component {
             "data": JSON.stringify(saveData),
             "isSnapshot": isSnapshot
         }
-        axios.post(`${constants.ROOT_URL}/api/user/map/save/`, body, getAuthHeader())
+        axios.post(`${constants.ROOT_URL}/api/user/map/save`, body, getAuthHeader())
             .then(() => {
-                axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+                axios.get(`${constants.ROOT_URL}/api/user/maps`, getAuthHeader())
                     .then((response) => {
                         dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
                         dispatch({

--- a/src/components/modals/SaveCopy.js
+++ b/src/components/modals/SaveCopy.js
@@ -22,7 +22,7 @@ const SaveCopy = () => {
     const saveMap = () => {
         dispatch(saveCurrentMap(true))
             .then(() => {
-                axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+                axios.get(`${constants.ROOT_URL}/api/user/maps`, getAuthHeader())
                     .then((response) => {
                         dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
                         dispatch({

--- a/src/components/modals/SaveSnapshot.js
+++ b/src/components/modals/SaveSnapshot.js
@@ -13,7 +13,7 @@ const SaveSnapshot = () => {
     const saveMap = () => {
         dispatch(saveCurrentMap(false, true, name))
             .then(() => {
-                axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+                axios.get(`${constants.ROOT_URL}/api/user/maps`, getAuthHeader())
                     .then((response) => {
                         dispatch({ type: 'POPULATE_MY_MAPS', payload: response.data });
                         dispatch({

--- a/src/routes/ChangeDetails.js
+++ b/src/routes/ChangeDetails.js
@@ -146,7 +146,7 @@ class ChangeDetails extends Component {
             postcode: this.state.postcode.value,
             phone: this.state.phone.value,
         }
-        axios.post(`${constants.ROOT_URL}/api/user/details/`, body, getAuthHeader())
+        axios.post(`${constants.ROOT_URL}/api/user/details`, body, getAuthHeader())
             .then((response) => {
                 console.log("response", response);
                 console.log("change details", response);

--- a/src/routes/ChangeEmail.js
+++ b/src/routes/ChangeEmail.js
@@ -44,7 +44,7 @@ class ChangeEmail extends Component {
             let body = {
                 username: this.state.newEmail.value
             }
-            axios.post(`${constants.ROOT_URL}/api/user/email/`, body, getAuthHeader())
+            axios.post(`${constants.ROOT_URL}/api/user/email`, body, getAuthHeader())
                 .then((response) => {
                     console.log("change email", response);
                     if (response.status === 200) {

--- a/src/routes/FourOhFour.js
+++ b/src/routes/FourOhFour.js
@@ -26,12 +26,11 @@ class FourOhFour extends Component {
                 >
                     <h1>Error</h1>
                     <p>This page doesn't exist!</p>
-                    <div className="button button-large" onClick={() => { window.location = '/app/'; }}>Return to site</div>
+                    <div className="button button-large" onClick={() => { window.location = '/app'; }}>Return to site</div>
                 </div>
             </div>
         )
     }
 }
-
 
 export default FourOhFour;

--- a/src/routes/MapApp.js
+++ b/src/routes/MapApp.js
@@ -47,7 +47,7 @@ class MapApp extends Component {
 
     async fetchUserDetails() {
         try {
-            const details = await axios.get(`${constants.ROOT_URL}/api/user/details/`, getAuthHeader());
+            const details = await axios.get(`${constants.ROOT_URL}/api/user/details`, getAuthHeader());
 
             if (details.status === 200) {
                 analytics.setDimension(analytics._dimension.ORG_TYPE, details.data.organisationType);
@@ -76,7 +76,7 @@ class MapApp extends Component {
 
     async fetchUserMaps() {
         try {
-            const maps = await axios.get(`${constants.ROOT_URL}/api/user/maps/`, getAuthHeader())
+            const maps = await axios.get(`${constants.ROOT_URL}/api/user/maps`, getAuthHeader())
 
             if (maps.status === 200) {
                 this.props.dispatch({ type: 'POPULATE_MY_MAPS', payload: maps.data })

--- a/src/routes/MapApp.js
+++ b/src/routes/MapApp.js
@@ -53,7 +53,7 @@ class MapApp extends Component {
                 analytics.setDimension(analytics._dimension.ORG_TYPE, details.data.organisationType);
                 analytics.setDimension(analytics._dimension.ORG_ACTIVITY, details.data.organisationActivity);
                 //fire the initial page load analytics
-                analytics.pageview('/app/');
+                analytics.pageview('/app');
                 this.props.dispatch({ type: 'POPULATE_USER', payload: details.data[0] })
             } if (details.status === 401) {
                 //Service denied due to auth denied

--- a/src/routes/MyAccount.js
+++ b/src/routes/MyAccount.js
@@ -37,7 +37,7 @@ const AccountView = ({ initials }) => {
             flexDirection: 'column',
             alignItems: 'center'
         }}>
-            <Link to="/app/"
+            <Link to="/app"
                 className="modal-close"
             />
             <div className="my-account--option">

--- a/src/routes/Register.js
+++ b/src/routes/Register.js
@@ -154,7 +154,7 @@ class Register extends Component {
     };
     console.log("registration request", request);
     axios
-      .post(`${constants.ROOT_URL}/api/user/register/`, request)
+      .post(`${constants.ROOT_URL}/api/user/register`, request)
       .then(response => {
         console.log("register response", response);
         if (response.status === 200) {

--- a/src/routes/ResetPassword.js
+++ b/src/routes/ResetPassword.js
@@ -28,7 +28,7 @@ class ResetPassword extends Component {
         let request = {
             username: this.state.email.value,
         }
-        axios.post(`${constants.ROOT_URL}/api/user/password-reset/`, request)
+        axios.post(`${constants.ROOT_URL}/api/user/password-reset`, request)
             .then((response) => {
                 console.log("reset response", response);
                 this.setState({ success: true });

--- a/src/utils/saveMap.js
+++ b/src/utils/saveMap.js
@@ -32,5 +32,5 @@ export const saveExistingMap = async (existingMap) => {
         "isSnapshot": false
     }
 
-    return axios.post(`${constants.ROOT_URL}/api/user/map/save/`, body, getAuthHeader());
+    return axios.post(`${constants.ROOT_URL}/api/user/map/save`, body, getAuthHeader());
 }


### PR DESCRIPTION
#### What? Why?

Closes #178 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
In https://github.com/DigitalCommons/land-explorer-back-end/pull/33 I added unit tests and tidied up the docs for the API routes. I removed the trailing slash from some API routes and didn't realise it would make a difference, but the routes stopped working because the front-end API calls still use the trailing slashes.

To be consistent and avoid confusion, we'll just remove all trailing slashes from API routes. Most of the forum threads online recommend this e.g. https://stackoverflow.com/questions/61547014/restful-uri-trailing-slash-or-no-trailing-slash

We also remove trailing slash from links to the homepage '/app', since these are inconsistent and mean the page doesn't load.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Try saving/deleting a map. These are two of the routes that have been changed. (I've carefully checked that all API calls in the codebase are consistent, so don't think we need to manually test every API route)
- Click the LX logo in the top left and then refresh the page. Previously, this would go to a blank screen.

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
