### PR TITLE
LX-194 Prompt re-login if we get 401 Unauthorized error

### DIFF
--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -1,19 +1,11 @@
-import axios from 'axios';
-import constants from "../constants";
-import { getAuthHeader } from "../utils/Auth";
+import { getRequest } from './common/RequestActions';
 
 export const getUserDetails = () => {
-    return dispatch => {
-        axios.get(`${constants.ROOT_URL}/api/user/details`, getAuthHeader())
-            .then((response) => {
-                if (response.status === 200) {
-                    if (response.status === 200) {
-                        dispatch({ type: 'POPULATE_USER', payload: response.data[0] })
-                    }
-                } else {
-                    console.log("error", response.status);
-                }
-            })
+    return async dispatch => {
+        const userData = await dispatch(getRequest('/api/user/details'));
+        if (userData) {
+            dispatch({ type: 'POPULATE_USER', payload: userData });
+        }
     }
 }
 

--- a/src/actions/common/RequestActions.js
+++ b/src/actions/common/RequestActions.js
@@ -1,0 +1,52 @@
+import axios from 'axios';
+import constants from "../../constants";
+import { getAuthHeader } from '../../utils/Auth';
+
+/**
+ * Make a GET request to the given API endpoint.
+ * 
+ * If we hit a 401 Unauthorized error, timeout the session so the user returns to login screen.
+ * 
+ * @param {string} endpoint the API endpoint, starting '/api/'
+ * @returns {Promise<any>} the resulting data, or null if the request failed
+ */
+export const getRequest = endpoint => {
+    return async dispatch => {
+        try {
+            const response = await axios.get(`${constants.ROOT_URL}${endpoint}`, getAuthHeader());
+            return response.data;
+        } catch (err) {
+            console.error(`There was an error in ${endpoint} GET request`, err);
+
+            if (err.response.status === 401) {
+                dispatch({ type: 'SESSION_TIMED_OUT' });
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * Make a POST request to the given API endpoint.
+ * 
+ * If we hit a 401 Unauthorized error, timeout the session so the user returns to login screen.
+ * 
+ * @param {string} endpoint the API endpoint, starting '/api/'
+ * @param {any} body the data to include in the POST request
+ * @returns {Promise<boolean>} whether the request was successful
+ */
+export const postRequest = (endpoint, body) => {
+    return async dispatch => {
+        try {
+            await axios.post(`${constants.ROOT_URL}${endpoint}`, body, getAuthHeader());
+            return true;
+        } catch (err) {
+            console.error(`There was an error in ${endpoint} POST request`, err);
+
+            if (err.response.status === 401) {
+                dispatch({ type: 'SESSION_TIMED_OUT' });
+            }
+        }
+        return false;
+    }
+}

--- a/src/components/MenuMain.js
+++ b/src/components/MenuMain.js
@@ -4,17 +4,11 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import constants from '../constants';
 import analytics from "../analytics";
-import { logout } from '../utils/Auth';
 import { openModal } from '../actions/ModalActions';
 
 class MenuMain extends Component {
     constructor(props) {
         super(props);
-    }
-
-    logoutUser() {
-        logout();
-        this.props.history.push('/auth');
     }
 
     render() {
@@ -94,11 +88,8 @@ class MenuMain extends Component {
                                     marginBottom: '10px'
                                 }}
                             >
-                                <div className="button button-medium" onClick={this.logoutUser}
-                                /*onClick={(e) => {
-                                    e.preventDefault();
-                                    window.location = "/logout";
-                                }}*/
+                                <div className="button button-medium"
+                                    onClick={() => this.props.dispatch({ type: 'LOG_OUT' })}
                                 >Logout</div>
                             </div>
                         )

--- a/src/components/MenuProfile.js
+++ b/src/components/MenuProfile.js
@@ -6,7 +6,6 @@ import { openModal } from '../actions/ModalActions';
 import { changeUser } from '../actions/UserActions'
 import analytics from '../analytics';
 import constants from '../constants';
-import { logout } from '../utils/Auth';
 import withRouter from "../components/common/withRouter";
 
 class MenuProfile extends Component {
@@ -15,13 +14,8 @@ class MenuProfile extends Component {
         this.dispatchUserChange = this.dispatchUserChange.bind(this);
     }
 
-    logoutUser(e) {
-        logout();
-        this.props.router.navigate("/auth")
-    }
-
     dispatchUserChange(event) {
-        this.props.changeUser(event.target.id);
+        this.props.dispatch(changeUser(event.target.id));
     }
 
     ifPrivilegedDisplayButtons(privileged) {
@@ -39,7 +33,7 @@ class MenuProfile extends Component {
     }
 
     render() {
-        let { open, openModal, privileged } = this.props;
+        let { dispatch, open, privileged } = this.props;
         return (
             <div style={{
                 display: open ? 'block' : 'none',
@@ -53,7 +47,7 @@ class MenuProfile extends Component {
                     <div className="tooltip-menu-item"
                         onClick={() => {
                             analytics.pageview('/app/my-maps');
-                            openModal('myMaps');
+                            dispatch(openModal('myMaps'));
                         }}
                     >
                         My Maps
@@ -61,7 +55,7 @@ class MenuProfile extends Component {
                     <div className="tooltip-menu-item"
                         onClick={() => {
                             analytics.pageview('/app/my-shared-maps');
-                            openModal('mySharedMaps');
+                            dispatch(openModal('mySharedMaps'));
                         }}
                     >
                         Shared Maps
@@ -85,11 +79,8 @@ class MenuProfile extends Component {
                             marginBottom: '10px'
                         }}
                     >
-                        <div className="button button-medium" onClick={this.logoutUser.bind(this)}
-                        /*onClick={(e) => {
-                            e.preventDefault();
-                            window.location = "/logout";
-                        }}*/
+                        <div className="button button-medium"
+                            onClick={() => dispatch({ type: 'LOG_OUT' })}
                         >Logout</div>
                     </div>
                 </div>
@@ -107,4 +98,4 @@ const mapStateToProps = ({ menu, user }) => ({
     privileged: user.privileged
 });
 
-export default connect(mapStateToProps, { openModal, changeUser })(withRouter(MenuProfile));
+export default connect(mapStateToProps)(withRouter(MenuProfile));

--- a/src/reducers/AuthenticationReducer.js
+++ b/src/reducers/AuthenticationReducer.js
@@ -1,42 +1,34 @@
 const INITIAL_STATE = {
     authenticated: false,
-    loggedIn: false,
-    token: null
+    error: null
 }
 
 export default (state = INITIAL_STATE, action) => {
-    switch(action.type) {
-        case 'LOG_IN':
+    switch (action.type) {
+        case 'LOGGED_IN': {
             return {
-                ...state,
-                loggedIn: true
-            }
-        case 'LOG_OUT':
-            return {
-                ...state,
-                loggedIn: false
-            }
-        case 'AUTHENTICATE': {
-            return {
-                ...state,
-                authenticated: true
+                authenticated: true,
+                error: null
             }
         }
-        case 'DE_AUTHENTICATE': {
+        case 'FAILED_LOGIN': {
             return {
-                ...state,
-                authenticated: false
+                authenticated: false,
+                error: 'You have entered an invalid username or password.'
             }
         }
-        case 'SET_TOKEN': {
-            console.log("setting token");
+        case 'LOG_OUT': {
             return {
-                ...state,
-                token: action.payload,
-                tokenExpiry: Math.round(new Date().getTime() / 1000) + (24 * 3600),
+                authenticated: false,
+                error: null
             }
         }
-        
+        case 'SESSION_TIMED_OUT': {
+            return {
+                authenticated: false,
+                error: 'Your session has timed out. Please log back in.'
+            }
+        }
         default:
             return state;
     }

--- a/src/routes/Login.js
+++ b/src/routes/Login.js
@@ -1,51 +1,39 @@
 import axios from "axios";
-import React, { Component } from "react";
-import { connect } from "react-redux";
-import { Link } from "react-router-dom";
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from "react-redux";
+import { Link, useNavigate } from "react-router-dom";
 import * as Auth from "../utils/Auth";
 import Spinner from "../components/common/Spinner";
-import withRouter from "../components/common/withRouter";
 import Navbar from "../components/Navbar";
 import constants from "../constants";
 
-class Login extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      loggingIn: false,
-      error: false,
-      email: {
-        value: "",
-        valid: ""
-      },
-      password: {
-        value: "",
-        valid: ""
-      }
-    };
+const Login = ({ updateCarousel }) => {
+  const [loggingIn, setLoggingIn] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const authenticated = useSelector(state => state.authentication.authenticated);
+  const error = useSelector(state => state.authentication.error);
 
-    //If user is already logged in, redirect to app
-    if (Auth.isTokenActive()) {
-      this.props.history.push("/app");
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    updateCarousel(0);
+  }, [])
+
+  useEffect(() => {
+    //If user is logged in, redirect to app
+    if (authenticated && Auth.isTokenActive()) {
+      navigate("/app");
     }
-  }
+  }, [authenticated])
 
-  componentDidMount() {
-    this.props.updateCarousel(0);
-  }
-
-
-  handleSubmit = e => {
-    e.preventDefault();
-    this.login();
-  };
-
-  login = () => {
-    this.setState({ error: false, loggingIn: true });
+  const login = () => {
+    setLoggingIn(true);
 
     const loginDetails = new URLSearchParams({
-      username: this.state.email.value,
-      password: this.state.password.value,
+      username: email,
+      password: password,
       grant_type: "password"
     });
 
@@ -56,149 +44,126 @@ class Login extends Component {
       }
     };
 
-    axios
-      .post(`${constants.ROOT_URL}/api/token`, loginDetails, config)
+    axios.post(`${constants.ROOT_URL}/api/token`, loginDetails, config)
       .then(response => {
         console.log('login successful');
         Auth.setToken(response.data.access_token, response.data.expires_in);
-        this.props.router.navigate("/app");
+        dispatch({ type: 'LOGGED_IN' })
+        navigate("/app");
       })
       .catch(err => {
         console.log(err);
         if (err.response.status === 400) {
           console.log("wrong credentials");
         }
-        this.setState({ loggingIn: false, error: true });
+        setLoggingIn(false);
+        dispatch({ type: 'FAILED_LOGIN' });
       });
   };
 
-  render() {
-    let { password, email, loggingIn } = this.state;
-    return (
+  return (
+    <div
+      style={{
+        minHeight: "100vh"
+      }}
+    >
+      <Navbar limited={true} />
       <div
         style={{
-          minHeight: "100vh"
+          left: "50%",
+          top: "50%",
+          transform: "translateX(-50%) translateY(-50%)",
+          position: "absolute",
+          textAlign: "center",
+          display: loggingIn ? "block" : "none"
         }}
       >
-        <Navbar limited={true} />
-        <div
-          style={{
-            left: "50%",
-            top: "50%",
-            transform: "translateX(-50%) translateY(-50%)",
-            position: "absolute",
-            textAlign: "center",
-            display: loggingIn ? "block" : "none"
-          }}
-        >
-          <Spinner />
-        </div>
-        <div
-          style={{
-            height: "auto",
-            minHeight: "200px",
-            width: "500px",
-            maxWidth: "90vw",
-            background: "white",
-            position: "absolute",
-            left: "50%",
-            top: "50%",
-            boxSizing: "border-box",
-            transform: "translateX(-50%) translateY(-50%)",
-            textAlign: "center",
-            paddingLeft: "24px",
-            paddingRight: "24px",
-            display: loggingIn ? "none" : "block"
-          }}
-        >
-          <h2>Log In</h2>
-          {this.state.error && (
-            <p style={{ marginBottom: "12px" }}>
-              You have entered an invalid username or password
-            </p>
-          )}
-          <br />
-          <form onSubmit={this.handleSubmit}>
-            <input
-              type="text"
-              className="text-input"
-              placeholder="Email address"
-              value={email.value}
-              onChange={e => {
-                let value = e.target.value;
-                let valid = emailRegexp.test(value);
-                this.setState({
-                  email: { value, valid }
-                });
-              }}
-            />
-            <input
-              type="password"
-              className="text-input"
-              placeholder="Password"
-              value={password.value}
-              onChange={e => {
-                let value = e.target.value;
-                let valid = value.length > 5 && value.length < 13;
-                this.setState({
-                  password: { value, valid }
-                });
-              }}
-            />
-            <input
-              type="submit"
-              value="Log In"
-              className="button button-medium"
-              style={{
-                paddingTop: 0,
-                marginTop: "6px"
-              }}
-            />
-          </form>
-          <p>
-            or,{" "}
-            <Link
-              to="/auth/register"
-              style={{
-                textDecoration: "none",
-                color: "rgb(46, 203, 112)",
-                paddingBottom: "4px",
-                borderBottom: "1px solid rgb(46, 203, 112)"
-              }}
-            >
-              register new account
-            </Link>
-          </p>
-          <p>
-            or,{" "}
-            <Link
-              to="/auth/reset-password"
-              style={{
-                textDecoration: "none",
-                color: "rgb(46, 203, 112)",
-                paddingBottom: "4px",
-                borderBottom: "1px solid rgb(46, 203, 112)"
-              }}
-            >
-              reset password
-            </Link>
-          </p>
-        </div>
+        <Spinner />
       </div>
-    );
-  }
+      <div
+        style={{
+          height: "auto",
+          minHeight: "200px",
+          width: "500px",
+          maxWidth: "90vw",
+          background: "white",
+          position: "absolute",
+          left: "50%",
+          top: "50%",
+          boxSizing: "border-box",
+          transform: "translateX(-50%) translateY(-50%)",
+          textAlign: "center",
+          paddingLeft: "24px",
+          paddingRight: "24px",
+          display: loggingIn ? "none" : "block"
+        }}
+      >
+        <h2>Log In</h2>
+        {error && (
+          <p style={{ marginBottom: "12px" }}>
+            {error}
+          </p>
+        )}
+        <br />
+        <form onSubmit={(e) => {
+          e.preventDefault();
+          login();
+        }}>
+          <input
+            type="text"
+            className="text-input"
+            placeholder="Email address"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            className="text-input"
+            placeholder="Password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+          <input
+            type="submit"
+            value="Log In"
+            className="button button-medium"
+            style={{
+              paddingTop: 0,
+              marginTop: "6px"
+            }}
+          />
+        </form>
+        <p>
+          or,{" "}
+          <Link
+            to="/auth/register"
+            style={{
+              textDecoration: "none",
+              color: "rgb(46, 203, 112)",
+              paddingBottom: "4px",
+              borderBottom: "1px solid rgb(46, 203, 112)"
+            }}
+          >
+            register new account
+          </Link>
+        </p>
+        <p>
+          or,{" "}
+          <Link
+            to="/auth/reset-password"
+            style={{
+              textDecoration: "none",
+              color: "rgb(46, 203, 112)",
+              paddingBottom: "4px",
+              borderBottom: "1px solid rgb(46, 203, 112)"
+            }}
+          >
+            reset password
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
 }
 
-const emailRegexp = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-
-Login.propTypes = {};
-
-//export default connect(null)(Login);
-
-const mapStateToProps = ({ authentication, user }) => ({
-  authenticated: authentication.authenticated,
-  loggedIn: authentication.loggedIn,
-  user: user
-});
-
-export default withRouter(connect(mapStateToProps)(Login));
+export default Login;

--- a/src/routes/MapApp.js
+++ b/src/routes/MapApp.js
@@ -1,118 +1,69 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import axios from 'axios';
-import constants from '../constants';
-import withRouter from "../components/common/withRouter";
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
 import { isMobile } from 'react-device-detect';
-import analytics from '../analytics';
-
 import MapboxMap from '../components/MapboxMap';
 import Navbar from '../components/Navbar';
 import '../assets/styles/style.scss';
 import Tooltips from '../components/Tooltips';
 import Controls from '../components/Controls';
 import Spinner from '../components/common/Spinner';
-import { logout, getAuthHeader, isTokenActive } from '../utils/Auth';
+import * as Auth from "../utils/Auth";
 import { getMyMaps } from '../actions/MapActions'
+import { getUserDetails } from '../actions/UserActions';
 
-class MapApp extends Component {
+const MapApp = () => {
+    const authenticated = useSelector(state => state.authentication.authenticated);
+    const user = useSelector(state => state.user);
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            errors: false,
-            success: false
-        }
-    }
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
 
-    logoutUser() {
-        logout();
-        this.props.router.navigate("/auth", { replace: true });
-    }
-
-    componentDidMount() {
-        if (!isTokenActive()) {
-            console.log("no token, redirecting")
-            this.props.router.navigate("/auth", { replace: true });
-        }
-
-        this.fetchUserDetails();
-        this.props.dispatch(getMyMaps());
+    useEffect(() => {
+        dispatch(getUserDetails());
+        dispatch(getMyMaps());
 
         // if mobile, disable drawing tools
         if (isMobile) {
-            this.props.dispatch({ type: 'READ_ONLY_ON' });
+            dispatch({ type: 'READ_ONLY_ON' });
         }
-    }
+    }, [])
 
-    async fetchUserDetails() {
-        try {
-            const details = await axios.get(`${constants.ROOT_URL}/api/user/details`, getAuthHeader());
-
-            if (details.status === 200) {
-                analytics.setDimension(analytics._dimension.ORG_TYPE, details.data.organisationType);
-                analytics.setDimension(analytics._dimension.ORG_ACTIVITY, details.data.organisationActivity);
-                //fire the initial page load analytics
-                analytics.pageview('/app');
-                this.props.dispatch({ type: 'POPULATE_USER', payload: details.data[0] })
-            } if (details.status === 401) {
-                //Service denied due to auth denied
-                //Most probably token expired
-                this.logoutUser();
-
-            } else {
-                this.setState({ errors: details.data.errors })
-            }
-        } catch (err) {
-            console.log("There was an error", err);
-
-            if (err.response.status === 401) {
-                //Service denied due to auth denied
-                //Most probably token expired
-                this.logoutUser();
-            }
+    useEffect(() => {
+        // If not authenticated, remove token and redirect to login page
+        if (!authenticated || !Auth.isTokenActive()) {
+            Auth.removeToken();
+            console.log("no token, redirecting to login page");
+            navigate("/auth", { replace: true });
         }
-    }
+    }, [authenticated])
 
-    render() {
-        const { populated } = this.props.user;
-        console.log(this.props.user)
-        // If user details and maps have been populated render map
-        if (populated) {
-            /*
-                MapboxMap - MapboxGL instance, drawing tools, nav, ui etc.
-                Navbar - navbar at top of page
-                Tooltips - hover tooltips for nav items
-                Controls - map and layer controls in bottom right of app
-             */
-            return (
-                <div>
-                    <Tooltips />
-                    <MapboxMap user={this.props.user} />
-                    <Navbar limited={false} />
-                    <Controls />
+    // If user details have been populated, render map, else render loading spinner
+    if (user.populated) {
+        /*
+            Tooltips - hover tooltips for nav items
+            MapboxMap - MapboxGL instance, drawing tools, nav, ui etc.
+            Navbar - navbar at top of page
+            Controls - map and layer controls in bottom right of app
+         */
+        return (
+            <div>
+                <Tooltips />
+                <MapboxMap user={user} />
+                <Navbar limited={false} />
+                <Controls />
+            </div>
+        )
+    } else {
+        return (
+            <div className="full-height overflow-y">
+                <Navbar limited={true} />
+                <div className="centered">
+                    <Spinner />
                 </div>
-            )
-        } else {
-            // else render loading spinner
-            return (
-                <div className="full-height overflow-y">
-                    <Navbar limited={true} />
-                    <div className="centered">
-                        <Spinner />
-                    </div>
-                </div>
-            )
-        }
+            </div>
+        )
     }
 }
 
-
-const mapStateToProps = ({ authentication, user }) => ({
-    authenticated: authentication.authenticated,
-    loggedIn: authentication.loggedIn,
-    token: authentication.token,
-    user: user,
-});
-
-export default withRouter(connect(mapStateToProps)(MapApp));
+export default MapApp;

--- a/src/routes/Register.js
+++ b/src/routes/Register.js
@@ -606,7 +606,7 @@ class Register extends Component {
           </label>
         </div>
         <div className="FormControlButtons" style={{ padding: "10px" }}>
-          <Link to="/auth/">
+          <Link to="/auth">
             <div
               className="button button-cancel button-medium"
               style={{ display: "inline-block" }}

--- a/src/routes/ResetPassword.js
+++ b/src/routes/ResetPassword.js
@@ -71,7 +71,7 @@ class ResetPassword extends Component {
                         }}
                     >
                         <h3 style={{ fontWeight: 600 }}>Password reset requested</h3>
-                        <Link to="/auth/">
+                        <Link to="/auth">
                             <div className="button button-small" style={{ margin: 'auto' }}>Ok</div>
                         </Link>
                     </div>
@@ -122,7 +122,7 @@ class ResetPassword extends Component {
                                         paddingTop: 0,
                                     }}
                                 />
-                                <p><Link to="/auth/" style={{
+                                <p><Link to="/auth" style={{
                                     textDecoration: 'none',
                                     color: 'rgba(208, 2, 78, 0.95)',
                                     fontSize: '14px',

--- a/src/utils/Auth.js
+++ b/src/utils/Auth.js
@@ -1,11 +1,9 @@
-
-export function isTokenExist(){
+export function isTokenExist() {
     return localStorage.getItem('token') !== null && localStorage.getItem('token_expiry') !== null;
 }
 
-export function isTokenActive(){
-    if(isTokenExist())
-    {
+export function isTokenActive() {
+    if (isTokenExist()) {
         let now = new Date();
         let expiry = new Date(localStorage.getItem('token_expiry'));
         return now.getTime() < expiry.getTime();
@@ -13,7 +11,7 @@ export function isTokenActive(){
     return false;
 }
 
-export function setToken(token, expires_in){
+export function setToken(token, expires_in) {
     localStorage.setItem('token', token);
 
     var expiry = new Date();
@@ -22,23 +20,23 @@ export function setToken(token, expires_in){
     localStorage.setItem('token_expiry', expiry.toString());
 }
 
-export function getToken(){
+export function getToken() {
     return localStorage.getItem('token')
 }
 
-export function logout(){
+export function removeToken() {
     localStorage.removeItem('token');
     localStorage.removeItem('token_expiry');
 }
 
-export function getAuthHeader(){
-    return {headers: {'Authorization': "bearer " + localStorage.getItem('token')}};
+export function getAuthHeader() {
+    return { headers: { 'Authorization': "bearer " + localStorage.getItem('token') } };
 }
 
-export function bootstrap(){
-    return {headers: {'Authorization': "bearer " + localStorage.getItem('token')}};
+export function bootstrap() {
+    return { headers: { 'Authorization': "bearer " + localStorage.getItem('token') } };
 }
 
-export function test(){
+export function test() {
     return "TESTING CALL TO AUTH CLASS";
 }


### PR DESCRIPTION
#### What? Why?

Closes #194 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When we hit a 401 error on the client side, we now log out and say that the session timed out. The user can then log back in and re-authenticate properly. Previously, the client just stayed logged in but the API calls all silently failed.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1. Login
2. On the server, change the TOKEN_KEY in .env
3. Reload the server with pm2 restart 0
4. Try moving/editing a map, or opening MyMaps on the client. The session should time out and return to the login screen.

Other things to test, since they were refactored:
- manual log out
- logging in with incorrect password
- user registration

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
