### PR TITLE
LX-196 Improve GeoJSON export

### DIFF
--- a/src/components/modals/LinkShare.js
+++ b/src/components/modals/LinkShare.js
@@ -15,21 +15,19 @@ const LinkShare = () => {
     const generate = async () => {
         const mapId = mapToShare ? mapToShare.map.eid : currentMapId;
 
-        const result = await axios.post(`${constants.ROOT_URL}/api/user/map/share/public`,
-            {
-                mapId: mapId
-            },
-            getAuthHeader());
+        try {
+            const result = await axios.post(`${constants.ROOT_URL}/api/user/map/share/public`,
+                {
+                    mapId: mapId
+                },
+                getAuthHeader());
 
-        const { success, URI, message } = result.data;
-
-        if (success) {
-            const link = constants.ROOT_URL + URI;
+            const link = constants.ROOT_URL + result.data;
             setLinkText(link);
             setStage("copy");
         }
-        else {
-            setLinkText(message);
+        catch (err) {
+            setLinkText(err.response.data);
         }
     };
 

--- a/src/reducers/UserReducer.js
+++ b/src/reducers/UserReducer.js
@@ -17,17 +17,17 @@ const INITIAL_STATE = {
     phone: '',
     username: '',
     populated: false,
-    type:   '',
+    type: '',
     privileged: false,
 }
 
 export default (state = INITIAL_STATE, action) => {
-    switch(action.type) {
+    switch (action.type) {
         case 'POPULATE_USER':
             let councilType;
             //default is id 0
             //id 1 is rbkc
-            if(action.payload.council_id === 1) councilType = 'council';
+            if (action.payload.council_id === 1) councilType = 'council';
             return {
                 ...state,
                 ...action.payload,


### PR DESCRIPTION
#### What? Why?

Closes #196 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When sharing a GeoJSON link, we currently just display the map's data in our own internal non-standardised format. It doesn't include polygons/lines and also doesn't include datagroup objects.

This change instead outputs proper GeoJSON data that can be imported by other programs, with the same data that we include in the shapefiles.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Create a map and add some of your own drawings + enable a data group with objects
- Create a GeoJSON public link
- Open the link in a new tab and it should include all the data from your map

Also test creating a snapshot of the map, because some of this code was fixed at the same time (it was broken for new maps that had data groups enabled)

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
