### PR TITLE
Added background position propertyto snapshot-icon style

### DIFF
--- a/src/assets/styles/_modals.scss
+++ b/src/assets/styles/_modals.scss
@@ -329,6 +329,7 @@
   background-image: url('../img/icon-snapshot.svg');
   background-size: 24px 25px;
   background-repeat: no-repeat;
+  background-position: 50%;
 }
 
 .map-icon {


### PR DESCRIPTION
#### What? Why?

Closes  #203

Fixes misaligned snapshot icon.


#### What should we test?
Open the my maps modal and check the icon's alignment
