### PR TITLE
data cleared from redux store on logout

### DIFF
--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -19,7 +19,7 @@ import LandOwnershipReducer from "./LandOwnershipReducer";
 import DataGroupsReducer from "./DataGroupsReducer";
 import ConnectivityReducer from "./ConnectivityReducer";
 
-export default combineReducers({
+const appReducer = combineReducers({
   authentication: AuthenticationReducer,
   menu: MenuReducer,
   profileMenu: ProfileMenuReducer,
@@ -38,5 +38,15 @@ export default combineReducers({
   mapMeta: MapMetaReducer,
   landOwnership: LandOwnershipReducer,
   dataGroups: DataGroupsReducer,
-  connectivity: ConnectivityReducer
+  connectivity: ConnectivityReducer,
 });
+
+const rootReducer = (state, action) => {
+  // Clear all data in redux store to initial state when user logs out
+  if (action.type === "LOG_OUT") {
+    state = undefined;
+  }
+  return appReducer(state, action);
+};
+
+export default rootReducer;


### PR DESCRIPTION
#### What? Why?

Data leak on logout of LX (when logging in the last accessed map would be open, this happened across user accounts when using the same browser).


#### What should we test?

1. Log into LX
2. Open a map and dialogue if present
3. Logout and login again - the title bar should read `Untitled Map - add title to save map` and default map should be visible
4. Repeat the above switching while between user accounts in the same browser