### PR TITLE
256 implement fe functions for landreg back search

### DIFF
--- a/src/actions/LandOwnershipActions.js
+++ b/src/actions/LandOwnershipActions.js
@@ -1,5 +1,7 @@
 import { getRequest } from "./RequestActions";
 
+export const SHOW_PROPERTY_POLYGON = "SHOW_PROPERTY_POLYGON";
+
 export const highlightProperty = (property) => {
   return (dispatch) => {
     dispatch({
@@ -42,3 +44,14 @@ export const getRelatedProperties = (proprietorName) => {
     }
   };
 };
+
+export const showPropertyPolygon = (propertyCoordinates) => {
+  return (dispatch) => {
+    dispatch({
+      type: SHOW_PROPERTY_POLYGON,
+      payload: propertyCoordinates,
+    });
+  };
+};
+
+

--- a/src/actions/LandOwnershipActions.js
+++ b/src/actions/LandOwnershipActions.js
@@ -1,22 +1,44 @@
+import { getRequest } from "./RequestActions";
+
 export const highlightProperty = (property) => {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: "HIGHLIGHT_PROPERTY",
-      payload: property
+      payload: property,
     });
     dispatch(setActiveProperty(property.poly_id));
-  }
-}
+  };
+};
 
 export const setActiveProperty = (propertyId) => {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: "SET_ACTIVE_PROPERTY",
-      payload: propertyId
+      payload: propertyId,
     });
     dispatch({
-      type: 'SET_ACTIVE',
-      payload: 'Land Information'
+      type: "SET_ACTIVE",
+      payload: "Land Information",
     });
-  }
-}
+  };
+};
+
+export const getRelatedProperties = (proprietorName) => {
+  return async (dispatch) => {
+    const relatedProperties = await dispatch(
+      getRequest(`/api/search?proprietorName=${proprietorName}`)
+    );
+
+    if (relatedProperties.length > 0) {
+      dispatch({
+        type: "FETCH_PROPERTIES_SUCCESS",
+        payload: relatedProperties,
+      });
+    } else {
+      dispatch({
+        type: "FETCH_PROPERTIES_FAILURE",
+        payload: "No properties found",
+      });
+    }
+  };
+};

--- a/src/actions/LandOwnershipActions.js
+++ b/src/actions/LandOwnershipActions.js
@@ -27,19 +27,28 @@ export const setActiveProperty = (propertyId) => {
 
 export const getRelatedProperties = (proprietorName) => {
   return async (dispatch) => {
-    const relatedProperties = await dispatch(
-      getRequest(`/api/search?proprietorName=${proprietorName}`)
-    );
+    try {
+      dispatch({ type: "FETCH_PROPERTIES_LOADING" });
 
-    if (relatedProperties.length > 0) {
-      dispatch({
-        type: "FETCH_PROPERTIES_SUCCESS",
-        payload: relatedProperties,
-      });
-    } else {
+      const relatedProperties = await dispatch(
+        getRequest(`/api/search?proprietorName=${proprietorName}`)
+      );
+
+      if (relatedProperties.length > 0) {
+        dispatch({
+          type: "FETCH_PROPERTIES_SUCCESS",
+          payload: relatedProperties,
+        });
+      } else {
+        dispatch({
+          type: "FETCH_PROPERTIES_FAILURE",
+          payload: "No properties found",
+        });
+      }
+    } catch (error) {
       dispatch({
         type: "FETCH_PROPERTIES_FAILURE",
-        payload: "No properties found",
+        payload: "Error fetching properties",
       });
     }
   };
@@ -53,5 +62,3 @@ export const showPropertyPolygon = (propertyCoordinates) => {
     });
   };
 };
-
-

--- a/src/actions/MapActions.js
+++ b/src/actions/MapActions.js
@@ -1,344 +1,356 @@
-import { VERSION } from '../constants';
-import moment from 'moment';
-import { getRequest, postRequest } from './RequestActions';
-import { updateReadOnly } from './ReadOnlyActions';
+import { VERSION } from "../constants";
+import moment from "moment";
+import { getRequest, postRequest } from "./RequestActions";
+import { updateReadOnly } from "./ReadOnlyActions";
 
 export const getMyMaps = () => {
-    return async dispatch => {
-        const mapsData = await dispatch(getRequest('/api/user/maps'));
-        if (mapsData) {
-            console.log("Got my maps", mapsData);
-            dispatch({ type: 'POPULATE_MY_MAPS', payload: mapsData });
-        } else {
-            dispatch({ type: 'MY_MAPS_ERROR' });
-        }
+  return async (dispatch) => {
+    const mapsData = await dispatch(getRequest("/api/user/maps"));
+    if (mapsData) {
+      console.log("Got my maps", mapsData);
+      dispatch({ type: "POPULATE_MY_MAPS", payload: mapsData });
+    } else {
+      dispatch({ type: "MY_MAPS_ERROR" });
     }
-}
+  };
+};
 
 /** Get my maps from backend and reload the current map */
 const reloadCurrentMap = () => {
-    return async (dispatch, getState) => {
-        const currentMapId = getState().mapMeta.currentMapId;
-        if (currentMapId !== null) {
-            console.log("Reloading currently open map", currentMapId);
-            await dispatch(getMyMaps());
-            dispatch(openMap(currentMapId));
-        }
+  return async (dispatch, getState) => {
+    const currentMapId = getState().mapMeta.currentMapId;
+    if (currentMapId !== null) {
+      console.log("Reloading currently open map", currentMapId);
+      await dispatch(getMyMaps());
+      dispatch(openMap(currentMapId));
     }
-}
+  };
+};
 
 /** Get my maps from backend and load the map created most recently */
 export const loadNewestMap = () => {
-    return async (dispatch, getState) => {
-        await dispatch(getMyMaps());
+  return async (dispatch, getState) => {
+    await dispatch(getMyMaps());
 
-        const myMaps = getState().myMaps.maps;
+    const myMaps = getState().myMaps.maps;
 
-        if (myMaps.length > 0) {
-            const newMap = myMaps[myMaps.length - 1];
-            const newMapId = newMap.map.eid;
+    if (myMaps.length > 0) {
+      const newMap = myMaps[myMaps.length - 1];
+      const newMapId = newMap.map.eid;
 
-            console.log("Opening newest map", newMapId);
-            dispatch(openMap(newMapId));
-        }
+      console.log("Opening newest map", newMapId);
+      dispatch(openMap(newMapId));
     }
-}
+  };
+};
 
 /** Open specified map (if it exists in My Maps) */
 export const openMap = (mapId) => {
-    return (dispatch, getState) => {
-        const map = getState().myMaps.maps.find(item => item.map.eid === mapId);
-        if (map) {
-            const mapData = JSON.parse(map.map.data);
-            const isSnapshot = map.map.isSnapshot;
-            const lastModified = map.map.lastModified;
-            const writeAccess = map.access === 'WRITE';
+  return (dispatch, getState) => {
+    const map = getState().myMaps.maps.find((item) => item.map.eid === mapId);
+    if (map) {
+      const mapData = JSON.parse(map.map.data);
+      const isSnapshot = map.map.isSnapshot;
+      const lastModified = map.map.lastModified;
+      const writeAccess = map.access === "WRITE";
 
-            dispatch({
-                type: 'LOAD_MAP',
-                payload: {
-                    data: mapData,
-                    id: mapId,
-                    isSnapshot: isSnapshot,
-                    writeAccess: writeAccess,
-                    lastModified: shortenTimestamp(lastModified)
-                }
-            });
-            dispatch(updateReadOnly());
+      dispatch({
+        type: "LOAD_MAP",
+        payload: {
+          data: mapData,
+          id: mapId,
+          isSnapshot: isSnapshot,
+          writeAccess: writeAccess,
+          lastModified: shortenTimestamp(lastModified),
+        },
+      });
+      dispatch(updateReadOnly());
 
-            setTimeout(() => {
-                dispatch({
-                    type: 'CHANGE_MOVING_METHOD',
-                    payload: 'flyTo'
-                });
-            }, 1000);
+      setTimeout(() => {
+        dispatch({
+          type: "CHANGE_MOVING_METHOD",
+          payload: "flyTo",
+        });
+      }, 1000);
 
-            dispatch(postRequest('/api/user/map/view', { "eid": mapId }));
-        }
+      dispatch(postRequest("/api/user/map/view", { eid: mapId }));
     }
-}
+  };
+};
 
 export const deleteMap = (mapId) => {
-    return async (dispatch, getState) => {
-        const success = await dispatch(postRequest('/api/user/map/delete', { "eid": mapId }));
+  return async (dispatch, getState) => {
+    const success = await dispatch(
+      postRequest("/api/user/map/delete", { eid: mapId })
+    );
 
-        if (success) {
-            const currentMapId = getState().mapMeta.currentMapId;
+    if (success) {
+      const currentMapId = getState().mapMeta.currentMapId;
 
-            if (mapId === currentMapId) {
-                dispatch(newMap());
-            }
-            await dispatch(getMyMaps());
-        }
+      if (mapId === currentMapId) {
+        dispatch(newMap());
+      }
+      await dispatch(getMyMaps());
     }
-}
+  };
+};
 
 export const newMap = () => {
-    return (dispatch, getState) => {
-        dispatch({ type: 'NEW_MAP' });
-        setTimeout(() => {
-            dispatch({ type: 'CHANGE_MOVING_METHOD', payload: 'flyTo' })
-        }, 500);
-        dispatch(updateReadOnly());
-    }
-}
+  return (dispatch, getState) => {
+    dispatch({ type: "NEW_MAP" });
+    setTimeout(() => {
+      dispatch({ type: "CHANGE_MOVING_METHOD", payload: "flyTo" });
+    }, 500);
+    dispatch(updateReadOnly());
+  };
+};
 
 /**
  * If both 'copy' and 'snapshot' are false, we will save to existing map, or create a new map if it
  * is a new map.
- * 
+ *
  * @param {boolean} copy true if we are saving a copy of the current map
  * @param {boolean} snapshot true if we are saving a new snapshot of the current map
  * @param {string | undefined} name the name of the map that we want to save. If left undefined, we
  * will use the name of the existing map.
  * @return {boolean} true if save was successful.
  */
-export const saveCurrentMap = (copy = false, snapshot = false, name = undefined) => {
-    return async (dispatch, getState) => {
-        const map = getState().map;
-        const saveName = copy ? `Copy of ${map.name}` : name || map.name || 'Untitled Map';
+export const saveCurrentMap = (
+  copy = false,
+  snapshot = false,
+  name = undefined
+) => {
+  return async (dispatch, getState) => {
+    const map = getState().map;
+    const saveName = copy
+      ? `Copy of ${map.name}`
+      : name || map.name || "Untitled Map";
 
-        const saveData = {
-            map: {
-                ...map,
-                name: saveName,
-            },
-            drawings: getState().drawings,
-            markers: getState().markers,
-            mapLayers: {
-                landDataLayers: getState().mapLayers.landDataLayers,
-                myDataLayers: getState().dataGroups.activeGroups
-            },
-            version: VERSION,
-            name: saveName,
+    const saveData = {
+      map: {
+        ...map,
+        name: saveName,
+      },
+      drawings: getState().drawings,
+      markers: getState().markers,
+      mapLayers: {
+        landDataLayers: getState().mapLayers.landDataLayers,
+        myDataLayers: getState().dataGroups.activeGroups,
+      },
+      version: VERSION,
+      name: saveName,
+    };
 
-        };
+    console.log(
+      `Saving current map, copy:${copy} snapshot:${snapshot} data:`,
+      saveData
+    );
 
-        console.log(`Saving current map, copy:${copy} snapshot:${snapshot} data:`, saveData);
+    const body = {
+      eid: copy || snapshot ? null : getState().mapMeta.currentMapId,
+      name: saveName,
+      data: JSON.stringify(saveData),
+      isSnapshot: snapshot || getState().mapMeta.isSnapshot,
+    };
 
-        const body = {
-            eid: (copy || snapshot) ? null : getState().mapMeta.currentMapId,
-            name: saveName,
-            data: JSON.stringify(saveData),
-            isSnapshot: snapshot || getState().mapMeta.isSnapshot
-        };
-
-        return await dispatch(saveMapRequest('/api/user/map/save', body));
-    }
-}
+    return await dispatch(saveMapRequest("/api/user/map/save", body));
+  };
+};
 
 /** Save the current map if it is saved, otherwise do nothing. Return false iff error when saving */
 export const autoSave = () => {
-    return async (dispatch, getState) => {
-        if (getState().mapMeta.currentMapId) {
-            return await dispatch(saveCurrentMap());
-        }
-        return true;
+  return async (dispatch, getState) => {
+    if (getState().mapMeta.currentMapId) {
+      return await dispatch(saveCurrentMap());
     }
-}
+    return true;
+  };
+};
 
 /** Save the object data to a specified map. Return false iff failed to save to backend. */
 export const saveObjectToMap = (type, data, mapId) => {
-    return async (dispatch, getState) => {
-        const copyToCurrentMap = mapId === getState().mapMeta.currentMapId;
+  return async (dispatch, getState) => {
+    const copyToCurrentMap = mapId === getState().mapMeta.currentMapId;
 
-        if (copyToCurrentMap) {
-            // First save current changes, in case there are any new, unsaved objects.
-            // Otherwise, they will later overwrite the object that is being copied.
-            // TODO: can remove this when saving to backend no longer overwrites all existing objects
-            const success = await dispatch(autoSave());
-            if (!success) return false;
-        }
-
-        const body = {
-            object: data,
-            eid: mapId,
-        };
-        const success = await dispatch(saveMapRequest(`/api/user/map/save/${type}`, body));
-
-        if (success && copyToCurrentMap) {
-            // so that it appears on the current map
-            await dispatch(reloadCurrentMap());
-        }
-        return success;
+    if (copyToCurrentMap) {
+      // First save current changes, in case there are any new, unsaved objects.
+      // Otherwise, they will later overwrite the object that is being copied.
+      // TODO: can remove this when saving to backend no longer overwrites all existing objects
+      const success = await dispatch(autoSave());
+      if (!success) return false;
     }
-}
+
+    const body = {
+      object: data,
+      eid: mapId,
+    };
+    const success = await dispatch(
+      saveMapRequest(`/api/user/map/save/${type}`, body)
+    );
+
+    if (success && copyToCurrentMap) {
+      // so that it appears on the current map
+      await dispatch(reloadCurrentMap());
+    }
+    return success;
+  };
+};
 
 /** Edit the specified object's name and description. Return false iff failed to save to backend. */
 export const editMapObjectInfo = (type, uuid, newName, newDescription) => {
-    return async (dispatch, getState) => {
-        const payload = {
-            uuid,
-            name: newName,
-            description: newDescription,
-        };
+  return async (dispatch, getState) => {
+    const payload = {
+      uuid,
+      name: newName,
+      description: newDescription,
+    };
 
-        dispatch({
-            type: (type === "marker") ? 'RENAME_MARKER' : 'RENAME_POLYGON',
-            payload
-        });
+    dispatch({
+      type: type === "marker" ? "RENAME_MARKER" : "RENAME_POLYGON",
+      payload,
+    });
 
-        // If we are working on a saved map
-        if (getState().mapMeta.currentMapId) {
-            return await dispatch(saveMapRequest(`/api/user/edit/${type}`, payload));
-        }
-        return true;
+    // If we are working on a saved map
+    if (getState().mapMeta.currentMapId) {
+      return await dispatch(saveMapRequest(`/api/user/edit/${type}`, payload));
     }
-}
+    return true;
+  };
+};
 
 export const setLngLat = (lng, lat) => {
-    return async (dispatch, getState) => {
-        dispatch({
-            type: 'SET_LNG_LAT',
-            payload: [lng, lat]
-        });
+  return async (dispatch, getState) => {
+    dispatch({
+      type: "SET_LNG_LAT",
+      payload: [lng, lat],
+    });
 
-        const currentMapId = getState().mapMeta.currentMapId;
-        // If map is saved, save to back-end
-        if (currentMapId) {
-            const body = {
-                eid: currentMapId,
-                lngLat: [lng, lat]
-            };
-            await dispatch(saveMapRequest('/api/user/map/save/lngLat', body));
-        }
+    const currentMapId = getState().mapMeta.currentMapId;
+    // If map is saved, save to back-end
+    if (currentMapId) {
+      const body = {
+        eid: currentMapId,
+        lngLat: [lng, lat],
+      };
+      await dispatch(saveMapRequest("/api/user/map/save/lngLat", body));
     }
-}
+  };
+};
 
 export const setCurrentLocation = (lng, lat) => {
-    return dispatch => {
-        dispatch({
-            type: 'SET_CURRENT_LOCATION',
-            payload: [lng, lat]
-        });
-    }
-}
+  return (dispatch) => {
+    dispatch({
+      type: "SET_CURRENT_LOCATION",
+      payload: [lng, lat],
+    });
+  };
+};
 
 const saveMapZoom = (mapId, zoom) => {
-    return async dispatch => {
-        const body = {
-            eid: mapId,
-            zoom: zoom
-        };
-        await dispatch(saveMapRequest('/api/user/map/save/zoom', body));
-    }
-}
+  return async (dispatch) => {
+    const body = {
+      eid: mapId,
+      zoom: zoom,
+    };
+    await dispatch(saveMapRequest("/api/user/map/save/zoom", body));
+  };
+};
 
 export const zoomIn = () => {
-    return (dispatch, getState) => {
-        dispatch({ type: 'ZOOM_IN' });
+  return (dispatch, getState) => {
+    dispatch({ type: "ZOOM_IN" });
 
-        // If map is saved, save current Zoom to back-end
-        const currentMapId = getState().mapMeta.currentMapId;
-        if (currentMapId) {
-            dispatch(saveMapZoom(currentMapId, getState().map.zoom));
-        }
+    // If map is saved, save current Zoom to back-end
+    const currentMapId = getState().mapMeta.currentMapId;
+    if (currentMapId) {
+      dispatch(saveMapZoom(currentMapId, getState().map.zoom));
     }
-}
+  };
+};
 
 export const zoomOut = () => {
-    return (dispatch, getState) => {
-        dispatch({ type: 'ZOOM_OUT' });
+  return (dispatch, getState) => {
+    dispatch({ type: "ZOOM_OUT" });
 
-        // If map is saved, save current Zoom to back-end
-        const currentMapId = getState().mapMeta.currentMapId;
-        if (currentMapId) {
-            dispatch(saveMapZoom(currentMapId, getState().map.zoom));
-        }
+    // If map is saved, save current Zoom to back-end
+    const currentMapId = getState().mapMeta.currentMapId;
+    if (currentMapId) {
+      dispatch(saveMapZoom(currentMapId, getState().map.zoom));
     }
-}
+  };
+};
 
 export const setZoom = (zoom) => {
-    return (dispatch, getState) => {
-        dispatch({
-            type: 'SET_ZOOM',
-            payload: zoom
-        });
+  return (dispatch, getState) => {
+    dispatch({
+      type: "SET_ZOOM",
+      payload: zoom,
+    });
 
-        // If map is saved, save current Zoom to back-end
-        const currentMapId = getState().mapMeta.currentMapId;
-        if (currentMapId) {
-            dispatch(saveMapZoom(currentMapId, getState().map.zoom));
-        }
+    // If map is saved, save current Zoom to back-end
+    const currentMapId = getState().mapMeta.currentMapId;
+    if (currentMapId) {
+      dispatch(saveMapZoom(currentMapId, getState().map.zoom));
     }
-}
+  };
+};
 
 export const setSearchMarker = (lng, lat) => {
-    return dispatch => {
-        dispatch({
-            type: 'SET_SEARCH_MARKER',
-            payload: [lng, lat],
-        });
-    }
-}
+  return (dispatch) => {
+    dispatch({
+      type: "SET_SEARCH_MARKER",
+      payload: [lng, lat],
+    });
+  };
+};
 
 export const clearSearchMarker = () => {
-    return dispatch => {
-        dispatch({ type: 'CLEAR_SEARCH_MARKER' });
-    }
-}
+  return (dispatch) => {
+    dispatch({ type: "CLEAR_SEARCH_MARKER" });
+  };
+};
 
 /**
  * Make a POST request to the given API endpoint. Set the map saving and error state according to
  * what happens with the request.
- * 
+ *
  * @param {string} endpoint the API endpoint, starting '/api/'
  * @param {any} body the data to include in the POST request
  * @returns {boolean} whether the save was successful
  */
 const saveMapRequest = (endpoint, body) => {
-    return async (dispatch, getState) => {
-        const currentSaveError = getState().mapMeta.saveError;
-        dispatch({ type: 'MAP_SAVING' });
+  return async (dispatch, getState) => {
+    const currentSaveError = getState().mapMeta.saveError;
+    dispatch({ type: "MAP_SAVING" });
 
-        const success = await dispatch(postRequest(endpoint, body));
+    const success = await dispatch(postRequest(endpoint, body));
 
-        if (success) {
-            dispatch({
-                type: 'MAP_SAVED',
-                payload: {
-                    timestamp: moment().format("HH:mm")
-                }
-            });
+    if (success) {
+      dispatch({
+        type: "MAP_SAVED",
+        payload: {
+          timestamp: moment().format("HH:mm"),
+        },
+      });
 
-            if (currentSaveError && endpoint !== '/api/user/map/save') {
-                console.log('There was previously a save error so save the whole map');
-                dispatch(saveCurrentMap());
-            }
+      if (currentSaveError && endpoint !== "/api/user/map/save") {
+        console.log("There was previously a save error so save the whole map");
+        dispatch(saveCurrentMap());
+      }
 
-            return true;
-        }
-
-        dispatch({ type: 'MAP_SAVE_ERROR' });
-        return false;
+      return true;
     }
-}
+
+    dispatch({ type: "MAP_SAVE_ERROR" });
+    return false;
+  };
+};
 
 const shortenTimestamp = (timestamp) => {
-    const isToday = moment(timestamp).isSame(moment(), 'day');
-    if (isToday) {
-        return moment(timestamp).format("HH:mm");
-    } else {
-        return moment(timestamp).format("DD/MM/YY");
-    }
-}
+  const isToday = moment(timestamp).isSame(moment(), "day");
+  if (isToday) {
+    return moment(timestamp).format("HH:mm");
+  } else {
+    return moment(timestamp).format("DD/MM/YY");
+  }
+};

--- a/src/assets/styles/_buttons.scss
+++ b/src/assets/styles/_buttons.scss
@@ -31,6 +31,7 @@
   cursor: pointer;
   text-align: center;
   color: #fff;
+  border: none;
 }
 
 .button-reg-disabled {

--- a/src/assets/styles/_buttons.scss
+++ b/src/assets/styles/_buttons.scss
@@ -22,6 +22,17 @@
   }
 }
 
+.button-new {
+  width: 100%;
+  border-radius: 7px;
+  background-color: $primaryColor;
+  font-size: 12px;
+  padding: 10px 20px;
+  cursor: pointer;
+  text-align: center;
+  color: #fff;
+}
+
 .button-reg-disabled {
   opacity: 0.3;
   background: $buttonGreen;
@@ -45,7 +56,7 @@
 }
 
 .round-button-plus {
-  background-image: url('../img/icon-plus-small.svg');
+  background-image: url("../img/icon-plus-small.svg");
   background-size: 14px;
   background-position: center;
   background-repeat: no-repeat;
@@ -90,7 +101,7 @@
     margin-left: 0;
     height: 36px;
     width: 32px;
-    content: ' ';
+    content: " ";
   }
 
   .rounded-button-close {
@@ -137,7 +148,7 @@
   background-position: center;
   background-repeat: no-repeat;
   background-size: 65%;
-  background-image: url('../img/icon-menu-layers--white.svg');
+  background-image: url("../img/icon-menu-layers--white.svg");
   border-radius: 50%;
   z-index: 1000;
   position: fixed;
@@ -155,7 +166,7 @@
   background-position: center;
   background-repeat: no-repeat;
   background-size: 65%;
-  background-image: url('../img/icon-menu-key--white.svg');
+  background-image: url("../img/icon-menu-key--white.svg");
   border-radius: 50%;
   z-index: 1000;
   position: fixed;

--- a/src/assets/styles/_buttons.scss
+++ b/src/assets/styles/_buttons.scss
@@ -23,15 +23,29 @@
 }
 
 .button-new {
-  width: 100%;
+  // width: 100%;
   border-radius: 7px;
-  background-color: $primaryColor;
-  font-size: 12px;
-  padding: 10px 20px;
+  // background-color: $primaryColor;
+  text-align: center;
+  font-size: 14px;
+  padding: 12px 30px;
   cursor: pointer;
   text-align: center;
   color: #fff;
   border: none;
+
+  &.green {
+    background-color: $primaryColor;
+  }
+  &.blue {
+    background-color: #4a7abe;
+  }
+  &.full-width {
+    width: 100%;
+  }
+  &.half-width {
+    width: 50%;
+  }
 }
 
 .button-reg-disabled {

--- a/src/assets/styles/_datalayers.scss
+++ b/src/assets/styles/_datalayers.scss
@@ -5,6 +5,7 @@
   flex-direction: row;
   justify-content: space-between;
   padding: 0px 25px;
+  background-color: $trayBackground;
 }
 
 /* Tooltips for data group markers  */

--- a/src/assets/styles/_left-pane.scss
+++ b/src/assets/styles/_left-pane.scss
@@ -356,6 +356,7 @@ a.mapboxgl-ctrl-logo {
   background-size: 18px;
   background-repeat: no-repeat;
   background-position: 18px 50%;
+  background-color: $trayBackground;
 }
 
 .horizontal-divider {
@@ -377,6 +378,6 @@ a.mapboxgl-ctrl-logo {
 
   .draggable-item .tray-item-title,
   .tray-item .tray-item-title {
-    width: 302px;
+    width: 286px;
   }
 }

--- a/src/assets/styles/_left-pane.scss
+++ b/src/assets/styles/_left-pane.scss
@@ -80,7 +80,7 @@
   left: 72px;
   position: fixed;
   // width: 250px;
-  width: 400px;
+  width: calc(100vw - 72px);
   bottom: 0;
   top: 68px;
   // background-color: #f4f5f7;
@@ -97,7 +97,7 @@
   width: 100%;
   // background-color: #e4e6ea;
   // border-bottom: solid 1px #d1d1d1;
-  border-bottom: 1px solid #EEEEEE;
+  border-bottom: 1px solid #eeeeee;
 }
 
 .tray-title {
@@ -183,9 +183,11 @@
   }
 
   .tray-item-title {
-    width: 140px;
+    // width: 140px;
     padding-left: 48px;
     cursor: pointer;
+    width: calc(100% - 97px);
+    margin-right: 10px;
   }
 }
 
@@ -313,7 +315,9 @@
   }
 
   .tray-item-title {
-    width: 140px;
+    // width: 140px;
+    width: calc(100% - 97px);
+    margin-right: 10px;
   }
 
   transform-origin: 50% 50% 0px;
@@ -363,4 +367,16 @@ a.mapboxgl-ctrl-logo {
 .land-data-description {
   margin-top: 0;
   margin-left: 15px;
+}
+
+/* Desktop specific, as mobile first */
+@media screen and (min-width: 769px) {
+  .left-pane-tray {
+    width: 400px;
+  }
+
+  .draggable-item .tray-item-title,
+  .tray-item .tray-item-title {
+    width: 302px;
+  }
 }

--- a/src/assets/styles/_left-pane.scss
+++ b/src/assets/styles/_left-pane.scss
@@ -83,7 +83,8 @@
   width: 400px;
   bottom: 0;
   top: 68px;
-  background-color: #f4f5f7;
+  // background-color: #f4f5f7;
+  background-color: #fff;
   box-shadow: 3px 0 6px 0 rgba(0, 0, 0, 0.16);
   z-index: 100000;
   transition: transform 500ms ease;
@@ -94,8 +95,9 @@
 
 .tray-top {
   width: 100%;
-  background-color: #e4e6ea;
-  border-bottom: solid 1px #d1d1d1;
+  // background-color: #e4e6ea;
+  // border-bottom: solid 1px #d1d1d1;
+  border-bottom: 1px solid #EEEEEE;
 }
 
 .tray-title {
@@ -106,8 +108,10 @@
   align-items: center;
 
   .title {
-    font-weight: bold;
-    margin-left: 42px;
+    // font-weight: bold;
+    margin-left: 20px;
+    font-size: 24px;
+    color: $primaryColor;
   }
 
   .close-tray {
@@ -292,7 +296,7 @@
   position: absolute;
   width: 100%;
   height: 58px;
-  background-color: #f4f5f7;
+  // background-color: #f4f5f7;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/assets/styles/_left-pane.scss
+++ b/src/assets/styles/_left-pane.scss
@@ -79,7 +79,8 @@
 .left-pane-tray {
   left: 72px;
   position: fixed;
-  width: 250px;
+  // width: 250px;
+  width: 400px;
   bottom: 0;
   top: 68px;
   background-color: #f4f5f7;

--- a/src/assets/styles/_left-pane.scss
+++ b/src/assets/styles/_left-pane.scss
@@ -60,6 +60,15 @@
   .info.active {
     background-image: url("../img/icon-info--white.svg");
   }
+
+  .ownership {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 25.55 36.5'%3E%3Cpath d='M20.275,3A12.789,12.789,0,0,0,7.5,15.775C7.5,25.356,20.275,39.5,20.275,39.5S33.05,25.356,33.05,15.775A12.789,12.789,0,0,0,20.275,3Zm0,3.65a3.65,3.65,0,1,1-3.65,3.65A3.661,3.661,0,0,1,20.275,6.65Zm0,18.25a8.728,8.728,0,0,1-7.3-3.924c.036-2.409,4.873-3.741,7.3-3.741s7.263,1.332,7.3,3.741A8.728,8.728,0,0,1,20.275,24.9Z' transform='translate(-7.5 -3)' fill='%2327ae60'/%3E%3C/svg%3E");
+    background-size: 28px;
+
+    &.active {
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 25.55 36.5'%3E%3Cpath d='M20.275,3A12.789,12.789,0,0,0,7.5,15.775C7.5,25.356,20.275,39.5,20.275,39.5S33.05,25.356,33.05,15.775A12.789,12.789,0,0,0,20.275,3Zm0,3.65a3.65,3.65,0,1,1-3.65,3.65A3.661,3.661,0,0,1,20.275,6.65Zm0,18.25a8.728,8.728,0,0,1-7.3-3.924c.036-2.409,4.873-3.741,7.3-3.741s7.263,1.332,7.3,3.741A8.728,8.728,0,0,1,20.275,24.9Z' transform='translate(-7.5 -3)' fill='%23fff'/%3E%3C/svg%3E");
+    }
+  }
 }
 
 .left-pane-tray-container {
@@ -255,7 +264,7 @@
     border-radius: 50%;
   }
 
-  input:checked+.slider:before {
+  input:checked + .slider:before {
     background-color: $buttonGreen;
     -webkit-transform: translateX(9px);
     -ms-transform: translateX(9px);

--- a/src/assets/styles/_ownership-search.scss
+++ b/src/assets/styles/_ownership-search.scss
@@ -28,6 +28,7 @@
     fill: #d4d2d2;
   }
   &.active {
+    cursor: default;
     & h4 {
       color: $primaryColor;
     }
@@ -58,4 +59,19 @@
   width: 13px;
   height: 18px;
   display: block;
+}
+
+.loading-spinner {
+  border: 6px solid $lightNeutral; /* Light grey */
+  border-top: 6px solid $primaryColor; /* Blue */
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  animation: spin 1s linear infinite;
+  margin: 0 auto;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }

--- a/src/assets/styles/_ownership-search.scss
+++ b/src/assets/styles/_ownership-search.scss
@@ -27,6 +27,15 @@
     display: block;
     fill: #d4d2d2;
   }
+  &.active {
+    & h4 {
+      color: $primaryColor;
+    }
+    box-shadow: none;
+    & > i {
+      fill: $primaryColor;
+    }
+  }
 }
 
 .search-result__property-address {
@@ -37,11 +46,6 @@
 .search-result__property {
   margin: 0 0 5px 10px;
   padding: 0;
-}
-.search-result__proprietor {
-}
-
-.search-result__title-no {
 }
 
 .icon-proprietor {

--- a/src/assets/styles/_ownership-search.scss
+++ b/src/assets/styles/_ownership-search.scss
@@ -21,6 +21,7 @@
   margin-bottom: 20px;
   padding: 0 20px;
   display: flex;
+  cursor: pointer;
   & > i {
     width: 18px;
     display: block;

--- a/src/assets/styles/_ownership-search.scss
+++ b/src/assets/styles/_ownership-search.scss
@@ -1,0 +1,56 @@
+.search-results-container {
+  width: 100%;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.property-count {
+  font-size: 13px;
+  margin-bottom: 20px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #eeeeee;
+  padding: 20px;
+}
+
+.property-count--highlight {
+  color: $primaryColor;
+}
+
+.search-result {
+  font-size: 13px;
+  margin-bottom: 20px;
+  padding: 0 20px;
+  display: flex;
+  & > i {
+    width: 18px;
+    display: block;
+    fill: #d4d2d2;
+  }
+}
+
+.search-result__property-address {
+  margin: 0 0 5px;
+  padding: 0;
+}
+
+.search-result__property {
+  margin: 0 0 5px 10px;
+  padding: 0;
+}
+.search-result__proprietor {
+}
+
+.search-result__title-no {
+}
+
+.icon-proprietor {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+
+.icon-property {
+  width: 13px;
+  height: 18px;
+  display: block;
+}

--- a/src/assets/styles/_pagination.scss
+++ b/src/assets/styles/_pagination.scss
@@ -1,0 +1,20 @@
+.pagination {
+  list-style: none;
+  display: flex;
+}
+
+.page-item {
+  padding: 10px;
+  border: 1px solid $primaryColor;
+  cursor: pointer;
+}
+
+.button-style {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.button-style:focus {
+  outline: none;
+}

--- a/src/assets/styles/_pagination.scss
+++ b/src/assets/styles/_pagination.scss
@@ -4,15 +4,28 @@
 }
 
 .page-item {
-  padding: 10px;
-  border: 1px solid $primaryColor;
-  cursor: pointer;
+  border: 0px solid $primaryColor;
+  display: block;
+  &.prev {
+    border-radius: 5px 0 0 5px;
+  }
+  &.next {
+    border-radius: 0 5px 5px 0;
+  }
 }
 
-.button-style {
-  background-color: transparent;
+.page-link {
+  margin: 0;
+  padding: 5px 10px;
   border: none;
+  color: $primaryColor;
+  background-color: transparent;
   cursor: pointer;
+  &.active {
+    background-color: $primaryColor;
+    color: #fff;
+    box-shadow: none;
+  }
 }
 
 .button-style:focus {

--- a/src/assets/styles/_pagination.scss
+++ b/src/assets/styles/_pagination.scss
@@ -1,6 +1,9 @@
 .pagination {
   list-style: none;
   display: flex;
+  margin: 0 20px 20px;
+  padding: 0;
+  justify-content: center;
 }
 
 .page-item {

--- a/src/assets/styles/_pagination.scss
+++ b/src/assets/styles/_pagination.scss
@@ -1,7 +1,16 @@
+.pagination-container {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  padding: 20px 0 20px;
+  background-color: #ffffffcc;
+  border-top: 1px solid #eeeeee;
+}
+
 .pagination {
   list-style: none;
   display: flex;
-  margin: 0 20px 20px;
+  margin: 0 20px;
   padding: 0;
   justify-content: center;
 }

--- a/src/assets/styles/_properties.scss
+++ b/src/assets/styles/_properties.scss
@@ -15,16 +15,17 @@
 }
 
 .property-details-title {
-  font-size: 24px;
+  font-size: 20px;
   color: $primaryColor;
   margin-bottom: 20px;
 }
 
 .property-details-section {
   box-sizing: border-box;
-  border-top: 2px solid $midNeutral2;
+  border-top: 1px solid $midNeutral2;
   padding: 20px 0;
-  font-size: 18px;
+  font-size: 16px;
+  line-height: 1.25em;
 }
 
 .property-details-section__inner {
@@ -32,9 +33,8 @@
 }
 
 .property-details-section__title {
-  font-size: 18px;
   color: $primaryColor;
-  margin: 0;
+  margin-bottom: 5px;
 }
 
 .property-details-section__value,

--- a/src/assets/styles/_properties.scss
+++ b/src/assets/styles/_properties.scss
@@ -46,6 +46,12 @@
   font-size: 14px;
 }
 
+.property__clear-property {
+  margin-top: 15px;
+  display: flex;
+  justify-content: flex-end;
+}
+
 /* Desktop specific, as mobile first */
 @media screen and (min-width: 769px) {
   .property-details-section__inner {

--- a/src/assets/styles/_properties.scss
+++ b/src/assets/styles/_properties.scss
@@ -1,8 +1,58 @@
-.property-id-number{
-    cursor: pointer;
-    margin: 0;
+.property-id-number {
+  cursor: pointer;
+  margin: 0;
 }
 
-.highlighted{
-    color: red;
+.highlighted {
+  color: red;
+}
+
+.property-details {
+  height: auto;
+  width: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.property-details-title {
+  font-size: 24px;
+  color: $primaryColor;
+  margin-bottom: 20px;
+}
+
+.property-details-section {
+  box-sizing: border-box;
+  border-top: 2px solid $midNeutral2;
+  padding: 20px 0;
+  font-size: 18px;
+}
+
+.property-details-section__inner {
+  box-sizing: border-box;
+}
+
+.property-details-section__title {
+  font-size: 18px;
+  color: $primaryColor;
+  margin: 0;
+}
+
+.property-details-section__value,
+.property-details-section__small-print {
+  color: $darkNeutral;
+}
+
+.property-details-section__small-print {
+  font-size: 14px;
+}
+
+/* Desktop specific, as mobile first */
+@media screen and (min-width: 769px) {
+  .property-details-section__inner {
+    display: flex;
+
+    & > div {
+      width: 50%;
+    }
+  }
 }

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -44,8 +44,10 @@ $toolbarAccent: #e3e3e5;
 $trayBackground: #eff0f2;
 $trayAccent: #e5e7eb;
 
-$neutral: #E9E7E7;
-$midNeutral: #B1B1B1;
+$neutral: #e9e7e7;
+$darkNeutral: #707070;
+$midNeutral: #b1b1b1;
+$midNeutral2: #d4d2d2;
 $lightNeutral: #f5f5f5;
 
 /** Mixins **/

--- a/src/assets/styles/style.scss
+++ b/src/assets/styles/style.scss
@@ -11,6 +11,7 @@
 @import "my-account";
 @import "properties";
 @import "datalayers";
+@import "pagination";
 
 html {
   text-rendering: optimizeLegibility;

--- a/src/assets/styles/style.scss
+++ b/src/assets/styles/style.scss
@@ -11,6 +11,7 @@
 @import "my-account";
 @import "properties";
 @import "datalayers";
+@import "ownership-search";
 @import "pagination";
 
 html {

--- a/src/components/common/Button.js
+++ b/src/components/common/Button.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+const Button = ({ type, buttonAction }) => {
+  return (
+    <button className="btn-primary" type={type} onClick={buttonAction}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/common/Button.js
+++ b/src/components/common/Button.js
@@ -1,8 +1,8 @@
 import React from "react";
 
-const Button = ({ type, buttonAction }) => {
+const Button = ({ buttonClass, type, children, buttonAction }) => {
   return (
-    <button className="btn-primary" type={type} onClick={buttonAction}>
+    <button className={buttonClass} type={type} onClick={buttonAction}>
       {children}
     </button>
   );

--- a/src/components/common/Pagination.js
+++ b/src/components/common/Pagination.js
@@ -40,7 +40,7 @@ const Pagination = ({
   console.log("last Page: ", lastPage);
 
   return (
-    <nav>
+    <nav className="pagination-container">
       <ul className="pagination">
         <li className="page-item prev">
           <button

--- a/src/components/common/Pagination.js
+++ b/src/components/common/Pagination.js
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+
+const Pagination = ({
+  pagesDisplayed,
+  currentPage,
+  setCurrentPage,
+  noOfPages,
+  itemsPerPage,
+}) => {
+  const [pageNumberLimit, setPageNumberLimit] = useState(pagesDisplayed);
+  const [maxPageNumberLimit, setMaxPageNumberLimit] = useState(pagesDisplayed);
+  const [minPageNumberLimit, setMinPageNumberLimit] = useState(0);
+
+  const pageNumbers = [...Array(noOfPages + 1).keys()].slice(1);
+  const lastPage = pageNumbers[pageNumbers.length - 1];
+  const firstPage = pageNumbers[0];
+
+  const paginate = (pageNumber) => setCurrentPage(pageNumber);
+  const nextPage = () => {
+    if (currentPage < noOfPages) {
+      setCurrentPage(currentPage + 1);
+    }
+    if (currentPage + 1 > maxPageNumberLimit) {
+      setMaxPageNumberLimit(maxPageNumberLimit + pageNumberLimit);
+      setMinPageNumberLimit(minPageNumberLimit + pageNumberLimit);
+    }
+  };
+  const previousPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+    }
+    if ((currentPage - 1) % pageNumberLimit === 0) {
+      setMaxPageNumberLimit(maxPageNumberLimit - pageNumberLimit);
+      setMinPageNumberLimit(minPageNumberLimit - pageNumberLimit);
+    }
+  };
+
+  console.log("Items per page: ", itemsPerPage);
+  console.log("first Page: ", firstPage);
+  console.log("last Page: ", lastPage);
+
+  return (
+    <nav>
+      <ul className="pagination">
+        <li className="page-item prev">
+          <button
+            className="page-link"
+            onClick={previousPage}
+            disabled={currentPage === firstPage}
+          >
+            Prev
+          </button>
+        </li>
+        {pageNumbers.length > maxPageNumberLimit && currentPage > 5 && (
+          <li className="ellipsis page-item" onClick={previousPage}>
+            &hellip;
+          </li>
+        )}
+        {pageNumbers.map((number) => {
+          if (number < maxPageNumberLimit + 1 && number > minPageNumberLimit) {
+            return (
+              <li key={number} className="page-item" id={number}>
+                <button
+                  onClick={() => paginate(number)}
+                  className={`page-link ${
+                    currentPage === number ? "active" : null
+                  }`}
+                >
+                  {number}
+                </button>
+              </li>
+            );
+          } else {
+            return null;
+          }
+        })}
+        {pageNumbers.length > maxPageNumberLimit &&
+          currentPage !== lastPage && (
+            <li className="ellipsis page-item" onClick={nextPage}>
+              &hellip;
+            </li>
+          )}
+        <li className="page-item next">
+          <button
+            className="page-link"
+            onClick={nextPage}
+            disabled={currentPage === lastPage}
+          >
+            Next
+          </button>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/src/components/common/Tooltips.js
+++ b/src/components/common/Tooltips.js
@@ -68,7 +68,7 @@ const Tooltips = () => {
         delayShow={tooltipDelay}
         globalEventOff={isMobile ? "click" : undefined}
       >
-        Related Properties
+        Ownership Search
       </ReactTooltip>
     </>
   );

--- a/src/components/common/Tooltips.js
+++ b/src/components/common/Tooltips.js
@@ -59,6 +59,17 @@ const Tooltips = () => {
       >
         Land Information
       </ReactTooltip>
+      <ReactTooltip
+        id="ttRelatedProperties"
+        className="tooltip no-xs"
+        place="right"
+        type="light"
+        effect="solid"
+        delayShow={tooltipDelay}
+        globalEventOff={isMobile ? "click" : undefined}
+      >
+        Related Properties
+      </ReactTooltip>
     </>
   );
 };

--- a/src/components/left-pane/LeftPane.js
+++ b/src/components/left-pane/LeftPane.js
@@ -162,6 +162,7 @@ const LeftPane = ({ drawControl }) => {
       <LeftPaneRelatedProperties
         open={open && active === "Related Properties"}
         onClose={closeTray}
+        itemsPerPage={10}
       />
     </nav>
   );

--- a/src/components/left-pane/LeftPane.js
+++ b/src/components/left-pane/LeftPane.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import LeftPaneInfo from "./LeftPaneInfo";
 import LeftPaneLandData from "./LeftPaneLandData";
 import LeftPaneDrawingTools from "./LeftPaneDrawingTools";
+import LeftPaneRelatedProperties from "./LeftPaneRelatedProperties";
 import analytics from "../../analytics";
 import { autoSave } from "../../actions/MapActions";
 import { isMobile } from "react-device-detect";
@@ -125,7 +126,22 @@ const LeftPane = ({ drawControl }) => {
           data-tip
           data-for="ttInfo"
         />
+        <div
+          className={`left-pane-icon info ${
+            active === "Related Properties" && "active"
+          }`}
+          onClick={() => {
+            analytics.event(
+              analytics._event.LEFT_PANE + " Related Properties",
+              "Open"
+            );
+            clickIcon("Related Properties");
+          }}
+          data-tip
+          data-for="ttRelatedProperties"
+        />
       </div>
+
       {
         // If not read only, render drawing tools
         !readOnly && (
@@ -141,6 +157,10 @@ const LeftPane = ({ drawControl }) => {
       <LeftPaneLandData open={open} active={active} onClose={closeTray} />
       <LeftPaneInfo
         open={open && active === "Land Information"}
+        onClose={closeTray}
+      />
+      <LeftPaneRelatedProperties
+        open={open && active === "Related Properties"}
         onClose={closeTray}
       />
     </nav>

--- a/src/components/left-pane/LeftPane.js
+++ b/src/components/left-pane/LeftPane.js
@@ -128,14 +128,14 @@ const LeftPane = ({ drawControl }) => {
         />
         <div
           className={`left-pane-icon ownership ${
-            active === "Related Properties" && "active"
+            active === "Ownership Search" && "active"
           }`}
           onClick={() => {
             analytics.event(
-              analytics._event.LEFT_PANE + " Related Properties",
+              analytics._event.LEFT_PANE + " Ownership Search",
               "Open"
             );
-            clickIcon("Related Properties");
+            clickIcon("Ownership Search");
           }}
           data-tip
           data-for="ttRelatedProperties"
@@ -160,7 +160,7 @@ const LeftPane = ({ drawControl }) => {
         onClose={closeTray}
       />
       <LeftPaneRelatedProperties
-        open={open && active === "Related Properties"}
+        open={open && active === "Ownership Search"}
         onClose={closeTray}
         itemsPerPage={10}
       />

--- a/src/components/left-pane/LeftPane.js
+++ b/src/components/left-pane/LeftPane.js
@@ -127,7 +127,7 @@ const LeftPane = ({ drawControl }) => {
           data-for="ttInfo"
         />
         <div
-          className={`left-pane-icon info ${
+          className={`left-pane-icon ownership ${
             active === "Related Properties" && "active"
           }`}
           onClick={() => {

--- a/src/components/left-pane/LeftPaneInfo.js
+++ b/src/components/left-pane/LeftPaneInfo.js
@@ -1,44 +1,50 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
-import LeftPaneTray from './LeftPaneTray';
-import MarkerSection from './MarkerSection';
-import PolygonSection from './PolygonSection';
-import PropertySection from './PropertySection';
+import React from "react";
+import { useSelector } from "react-redux";
+import LeftPaneTray from "./LeftPaneTray";
+import MarkerSection from "./MarkerSection";
+import PolygonSection from "./PolygonSection";
+import PropertySection from "./PropertySection";
 
 const LeftPaneInfo = ({ onClose, open }) => {
-    const markers = useSelector(state => state.markers.markers);
-    const polygons = useSelector(state => state.drawings.polygons);
-    const properties = useSelector(state => state.landOwnership.highlightedProperties);
+  const markers = useSelector((state) => state.markers.markers);
+  const polygons = useSelector((state) => state.drawings.polygons);
+  const properties = useSelector(
+    (state) => state.landOwnership.highlightedProperties
+  );
+  const otherProperties = useSelector(
+    (state) => state.relatedProperties.properties
+  );
 
-    return <LeftPaneTray
-        title="Land Information"
-        open={open}
-        onClose={onClose}
-    >
-        {
-            (polygons.length || markers.length || properties.length) ? (
-                <>
-                    {markers.map((marker, i) =>
-                        <MarkerSection marker={marker} key={`marker-${i}`} />
-                    )}
-                    {polygons.map((polygon, i) =>
-                        <PolygonSection polygon={polygon} key={`polygon-${i}`} />
-                    )}
-                    {properties.map((property, i) =>
-                        <PropertySection property={property} key={`property-${i}`} />
-                    )}
-                </>
-            ) : (
-                <div style={{
-                    width: '100%',
-                    textAlign: 'center',
-                    marginTop: '24px'
-                }}>
-                    No drawn objects or selected properties.
-                </div>
-            )
-        }
+  return (
+    <LeftPaneTray title="Land Information" open={open} onClose={onClose}>
+      {polygons.length || markers.length || properties.length ? (
+        <>
+          {markers.map((marker, i) => (
+            <MarkerSection marker={marker} key={`marker-${i}`} />
+          ))}
+          {polygons.map((polygon, i) => (
+            <PolygonSection polygon={polygon} key={`polygon-${i}`} />
+          ))}
+          {properties.map((property, i) => (
+            <PropertySection property={property} key={`property-${i}`} />
+          ))}
+          {otherProperties.map((property, i) => (
+            <PropertySection property={property} key={`property-${i}`} />
+          ))}
+        </>
+      ) : (
+        <div
+          style={{
+            width: "100%",
+            textAlign: "center",
+            marginTop: "24px",
+          }}
+        >
+          No drawn objects or selected properties.
+        </div>
+      )}
     </LeftPaneTray>
-}
+  );
+};
 
 export default LeftPaneInfo;

--- a/src/components/left-pane/LeftPaneInfo.js
+++ b/src/components/left-pane/LeftPaneInfo.js
@@ -11,9 +11,6 @@ const LeftPaneInfo = ({ onClose, open }) => {
   const properties = useSelector(
     (state) => state.landOwnership.highlightedProperties
   );
-  const otherProperties = useSelector(
-    (state) => state.relatedProperties.properties
-  );
 
   return (
     <LeftPaneTray title="Land Information" open={open} onClose={onClose}>
@@ -26,9 +23,6 @@ const LeftPaneInfo = ({ onClose, open }) => {
             <PolygonSection polygon={polygon} key={`polygon-${i}`} />
           ))}
           {properties.map((property, i) => (
-            <PropertySection property={property} key={`property-${i}`} />
-          ))}
-          {otherProperties.map((property, i) => (
             <PropertySection property={property} key={`property-${i}`} />
           ))}
         </>

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -1,0 +1,25 @@
+import React from "react";
+import LeftPaneTray from "./LeftPaneTray";
+import { useSelector } from "react-redux";
+import RelatedProperties from "./RelatedProperties";
+
+const LeftPaneRelatedProperties = ({ onClose, open }) => {
+  const otherProperties = useSelector(
+    (state) => state.relatedProperties.properties
+  );
+  return (
+    <LeftPaneTray title="Related Properties" open={open} onClose={onClose}>
+      {otherProperties.length ? (
+        <>
+          {otherProperties.map((property, i) => (
+            <RelatedProperties property={property} key={`property-${i}`} />
+          ))}
+        </>
+      ) : (
+        <div>No related Properties</div>
+      )}
+    </LeftPaneTray>
+  );
+};
+
+export default LeftPaneRelatedProperties;

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import LeftPaneTray from "./LeftPaneTray";
 import { useSelector } from "react-redux";
 import RelatedProperties from "./RelatedProperties";
@@ -8,7 +8,10 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
     (state) => state.relatedProperties.properties
   );
 
-  const [currentPage, setCurrentPage] = React.useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageNumberLimit, setPageNumberLimit] = useState(5);
+  const [maxPageNumberLimit, setMaxPageNumberLimit] = useState(5);
+  const [minPageNumberLimit, setMinPageNumberLimit] = useState(0);
 
   // Use a Set to store unique properties
   const uniqueProperties = new Set();
@@ -22,7 +25,7 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
 
   const propertyCount = filteredProperties.length;
 
-  // Index range for pagination
+  // Pagination
   const indexOfLastProperty = currentPage * itemsPerPage;
   const indexOfFirstProperty = indexOfLastProperty - itemsPerPage;
   const currentProperties = filteredProperties.slice(
@@ -39,10 +42,18 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
     if (currentPage < noOfPages) {
       setCurrentPage(currentPage + 1);
     }
+    if (currentPage + 1 > maxPageNumberLimit) {
+      setMaxPageNumberLimit(maxPageNumberLimit + pageNumberLimit);
+      setMinPageNumberLimit(minPageNumberLimit + pageNumberLimit);
+    }
   };
   const previousPage = () => {
     if (currentPage > 1) {
       setCurrentPage(currentPage - 1);
+    }
+    if ((currentPage - 1) % pageNumberLimit === 0) {
+      setMaxPageNumberLimit(maxPageNumberLimit - pageNumberLimit);
+      setMinPageNumberLimit(minPageNumberLimit - pageNumberLimit);
     }
   };
 
@@ -51,7 +62,7 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
   console.log("last Page: ", lastPage);
 
   return (
-    <LeftPaneTray title="Related Properties" open={open} onClose={onClose}>
+    <LeftPaneTray title="Ownership Search" open={open} onClose={onClose}>
       {filteredProperties.length ? (
         <>
           <div>{propertyCount} properties</div>
@@ -68,21 +79,42 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
                       onClick={previousPage}
                       disabled={currentPage === firstPage}
                     >
-                      Previous
+                      Prev
                     </button>
                   </li>
-                  {pageNumbers.map((number) => (
-                    <li key={number} className="page-item">
-                      <button
-                        onClick={() => paginate(number)}
-                        className={`page-link ${
-                          currentPage === number ? "active" : ""
-                        }`}
-                      >
-                        {number}
-                      </button>
-                    </li>
-                  ))}
+                  {pageNumbers.length > maxPageNumberLimit &&
+                    currentPage > 5 && (
+                      <li className="ellipsis page-item" onClick={previousPage}>
+                        &hellip;
+                      </li>
+                    )}
+                  {pageNumbers.map((number) => {
+                    if (
+                      number < maxPageNumberLimit + 1 &&
+                      number > minPageNumberLimit
+                    ) {
+                      return (
+                        <li key={number} className="page-item" id={number}>
+                          <button
+                            onClick={() => paginate(number)}
+                            className={`page-link ${
+                              currentPage === number ? "active" : null
+                            }`}
+                          >
+                            {number}
+                          </button>
+                        </li>
+                      );
+                    } else {
+                      return null;
+                    }
+                  })}
+                  {pageNumbers.length > maxPageNumberLimit &&
+                    currentPage != lastPage && (
+                      <li className="ellipsis page-item" onClick={nextPage}>
+                        &hellip;
+                      </li>
+                    )}
                   <li className="page-item">
                     <button
                       className="page-link"
@@ -98,7 +130,7 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
           </div>
         </>
       ) : (
-        <div>No related Properties</div>
+        <div>No Related Properties</div>
       )}
     </LeftPaneTray>
   );

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -39,7 +39,8 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
           <>
             <div className="property-count">
               <span className="property-count--highlight">
-                {currentProperties[0].proprietor_name_1}
+                {currentProperties[0].proprietor_name_1 &&
+                  currentProperties[0].proprietor_name_1}
               </span>{" "}
               has{" "}
               <span className="property-count--highlight">{propertyCount}</span>{" "}

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -9,6 +9,7 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
     (state) => state.relatedProperties.properties
   );
 
+  const [activeProperty, setActiveProperty] = useState(null);
   // Use a Set to store unique properties
   const uniqueProperties = new Set();
 
@@ -32,6 +33,11 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
     indexOfLastProperty
   );
 
+  // Pass down the active property to the RelatedProperties component
+  const handlePropertyClick = (property) => {
+    setActiveProperty(property);
+  };
+
   return (
     <LeftPaneTray title="Ownership Search" open={open} onClose={onClose}>
       <div className="search-results-container">
@@ -47,7 +53,12 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
               associated properties
             </div>
             {currentProperties.map((property, i) => (
-              <RelatedProperties key={property.title_no} property={property} />
+              <RelatedProperties
+                key={property.title_no}
+                property={property}
+                isActive={property === activeProperty}
+                onPropertyClick={() => handlePropertyClick(property)}
+              />
             ))}
             {noOfPages > 1 && (
               <Pagination

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -9,6 +9,9 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
     (state) => state.relatedProperties.properties
   );
 
+  // Set loading state
+  const loading = useSelector((state) => state.relatedProperties.loading);
+
   const [activeProperty, setActiveProperty] = useState(null);
   // Use a Set to store unique properties
   const uniqueProperties = new Set();
@@ -41,7 +44,13 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
   return (
     <LeftPaneTray title="Ownership Search" open={open} onClose={onClose}>
       <div className="search-results-container">
-        {filteredProperties.length ? (
+        {loading ? (
+          <div
+            style={{ width: "100%", marginTop: "50px", textAlign: "center" }}
+          >
+            <div className="loading-spinner"></div>
+          </div>
+        ) : filteredProperties.length ? (
           <>
             <div className="property-count">
               <span className="property-count--highlight">

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -59,7 +59,11 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
             )}
           </>
         ) : (
-          <div>No Related Properties</div>
+          <div
+            style={{ width: "100%", marginTop: "24px", textAlign: "center" }}
+          >
+            No Related Properties
+          </div>
         )}
       </div>
     </LeftPaneTray>

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -2,16 +2,12 @@ import React, { useState } from "react";
 import LeftPaneTray from "./LeftPaneTray";
 import { useSelector } from "react-redux";
 import RelatedProperties from "./RelatedProperties";
+import Pagination from "../common/Pagination";
 
 const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
   const otherProperties = useSelector(
     (state) => state.relatedProperties.properties
   );
-
-  const [currentPage, setCurrentPage] = useState(1);
-  const [pageNumberLimit, setPageNumberLimit] = useState(5);
-  const [maxPageNumberLimit, setMaxPageNumberLimit] = useState(5);
-  const [minPageNumberLimit, setMinPageNumberLimit] = useState(0);
 
   // Use a Set to store unique properties
   const uniqueProperties = new Set();
@@ -25,113 +21,47 @@ const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
 
   const propertyCount = filteredProperties.length;
 
-  // Pagination
+  // Pagination values
+  const [currentPage, setCurrentPage] = useState(1);
+  const noOfPages = Math.ceil(propertyCount / itemsPerPage);
   const indexOfLastProperty = currentPage * itemsPerPage;
   const indexOfFirstProperty = indexOfLastProperty - itemsPerPage;
+  // Chop up the properties array into pages
   const currentProperties = filteredProperties.slice(
     indexOfFirstProperty,
     indexOfLastProperty
   );
-  const noOfPages = Math.ceil(propertyCount / itemsPerPage);
-  const pageNumbers = [...Array(noOfPages + 1).keys()].slice(1);
-  const lastPage = pageNumbers[pageNumbers.length - 1];
-  const firstPage = pageNumbers[0];
-
-  const paginate = (pageNumber) => setCurrentPage(pageNumber);
-  const nextPage = () => {
-    if (currentPage < noOfPages) {
-      setCurrentPage(currentPage + 1);
-    }
-    if (currentPage + 1 > maxPageNumberLimit) {
-      setMaxPageNumberLimit(maxPageNumberLimit + pageNumberLimit);
-      setMinPageNumberLimit(minPageNumberLimit + pageNumberLimit);
-    }
-  };
-  const previousPage = () => {
-    if (currentPage > 1) {
-      setCurrentPage(currentPage - 1);
-    }
-    if ((currentPage - 1) % pageNumberLimit === 0) {
-      setMaxPageNumberLimit(maxPageNumberLimit - pageNumberLimit);
-      setMinPageNumberLimit(minPageNumberLimit - pageNumberLimit);
-    }
-  };
-
-  console.log("Items per page: ", itemsPerPage);
-  console.log("first Page: ", firstPage);
-  console.log("last Page: ", lastPage);
 
   return (
     <LeftPaneTray title="Ownership Search" open={open} onClose={onClose}>
-      {filteredProperties.length ? (
-        <>
-          <div>{propertyCount} properties</div>
-          {currentProperties.map((property, i) => (
-            <RelatedProperties key={property.title_no} property={property} />
-          ))}
-          <div className="pagination">
+      <div className="search-results-container">
+        {filteredProperties.length ? (
+          <>
+            <div className="property-count">
+              <span className="property-count--highlight">
+                {currentProperties[0].proprietor_name_1}
+              </span>{" "}
+              has{" "}
+              <span className="property-count--highlight">{propertyCount}</span>{" "}
+              associated properties
+            </div>
+            {currentProperties.map((property, i) => (
+              <RelatedProperties key={property.title_no} property={property} />
+            ))}
             {noOfPages > 1 && (
-              <nav>
-                <ul className="pagination">
-                  <li className="page-item">
-                    <button
-                      className="page-link"
-                      onClick={previousPage}
-                      disabled={currentPage === firstPage}
-                    >
-                      Prev
-                    </button>
-                  </li>
-                  {pageNumbers.length > maxPageNumberLimit &&
-                    currentPage > 5 && (
-                      <li className="ellipsis page-item" onClick={previousPage}>
-                        &hellip;
-                      </li>
-                    )}
-                  {pageNumbers.map((number) => {
-                    if (
-                      number < maxPageNumberLimit + 1 &&
-                      number > minPageNumberLimit
-                    ) {
-                      return (
-                        <li key={number} className="page-item" id={number}>
-                          <button
-                            onClick={() => paginate(number)}
-                            className={`page-link ${
-                              currentPage === number ? "active" : null
-                            }`}
-                          >
-                            {number}
-                          </button>
-                        </li>
-                      );
-                    } else {
-                      return null;
-                    }
-                  })}
-                  {pageNumbers.length > maxPageNumberLimit &&
-                    currentPage != lastPage && (
-                      <li className="ellipsis page-item" onClick={nextPage}>
-                        &hellip;
-                      </li>
-                    )}
-                  <li className="page-item">
-                    <button
-                      className="page-link"
-                      onClick={nextPage}
-                      disabled={currentPage === lastPage}
-                    >
-                      Next
-                    </button>
-                  </li>
-                </ul>
-              </nav>
+              <Pagination
+                pagesDisplayed={5}
+                currentPage={currentPage}
+                setCurrentPage={setCurrentPage}
+                noOfPages={noOfPages}
+                itemsPerPage={itemsPerPage}
+              />
             )}
-          </div>
-        </>
-      ) : (
-        <div>No Related Properties</div>
-      )}
+          </>
+        ) : (
+          <div>No Related Properties</div>
+        )}
+      </div>
     </LeftPaneTray>
   );
 };

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -7,12 +7,23 @@ const LeftPaneRelatedProperties = ({ onClose, open }) => {
   const otherProperties = useSelector(
     (state) => state.relatedProperties.properties
   );
+
+  // Use a Set to store unique properties
+  const uniqueProperties = new Set();
+
+  // Filter out duplicates and store unique properties
+  const filteredProperties = otherProperties.filter((property) => {
+    const isDuplicate = uniqueProperties.has(property.title_no);
+    uniqueProperties.add(property.title_no);
+    return !isDuplicate;
+  });
+
   return (
     <LeftPaneTray title="Related Properties" open={open} onClose={onClose}>
-      {otherProperties.length ? (
+      {filteredProperties.length ? (
         <>
-          {otherProperties.map((property, i) => (
-            <RelatedProperties property={property} key={`property-${i}`} />
+          {filteredProperties.map((property, i) => (
+            <RelatedProperties key={property.title_no} property={property} />
           ))}
         </>
       ) : (

--- a/src/components/left-pane/LeftPaneRelatedProperties.js
+++ b/src/components/left-pane/LeftPaneRelatedProperties.js
@@ -3,10 +3,12 @@ import LeftPaneTray from "./LeftPaneTray";
 import { useSelector } from "react-redux";
 import RelatedProperties from "./RelatedProperties";
 
-const LeftPaneRelatedProperties = ({ onClose, open }) => {
+const LeftPaneRelatedProperties = ({ onClose, open, itemsPerPage }) => {
   const otherProperties = useSelector(
     (state) => state.relatedProperties.properties
   );
+
+  const [currentPage, setCurrentPage] = React.useState(1);
 
   // Use a Set to store unique properties
   const uniqueProperties = new Set();
@@ -18,13 +20,82 @@ const LeftPaneRelatedProperties = ({ onClose, open }) => {
     return !isDuplicate;
   });
 
+  const propertyCount = filteredProperties.length;
+
+  // Index range for pagination
+  const indexOfLastProperty = currentPage * itemsPerPage;
+  const indexOfFirstProperty = indexOfLastProperty - itemsPerPage;
+  const currentProperties = filteredProperties.slice(
+    indexOfFirstProperty,
+    indexOfLastProperty
+  );
+  const noOfPages = Math.ceil(propertyCount / itemsPerPage);
+  const pageNumbers = [...Array(noOfPages + 1).keys()].slice(1);
+  const lastPage = pageNumbers[pageNumbers.length - 1];
+  const firstPage = pageNumbers[0];
+
+  const paginate = (pageNumber) => setCurrentPage(pageNumber);
+  const nextPage = () => {
+    if (currentPage < noOfPages) {
+      setCurrentPage(currentPage + 1);
+    }
+  };
+  const previousPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  console.log("Items per page: ", itemsPerPage);
+  console.log("first Page: ", firstPage);
+  console.log("last Page: ", lastPage);
+
   return (
     <LeftPaneTray title="Related Properties" open={open} onClose={onClose}>
       {filteredProperties.length ? (
         <>
-          {filteredProperties.map((property, i) => (
+          <div>{propertyCount} properties</div>
+          {currentProperties.map((property, i) => (
             <RelatedProperties key={property.title_no} property={property} />
           ))}
+          <div className="pagination">
+            {noOfPages > 1 && (
+              <nav>
+                <ul className="pagination">
+                  <li className="page-item">
+                    <button
+                      className="page-link"
+                      onClick={previousPage}
+                      disabled={currentPage === firstPage}
+                    >
+                      Previous
+                    </button>
+                  </li>
+                  {pageNumbers.map((number) => (
+                    <li key={number} className="page-item">
+                      <button
+                        onClick={() => paginate(number)}
+                        className={`page-link ${
+                          currentPage === number ? "active" : ""
+                        }`}
+                      >
+                        {number}
+                      </button>
+                    </li>
+                  ))}
+                  <li className="page-item">
+                    <button
+                      className="page-link"
+                      onClick={nextPage}
+                      disabled={currentPage === lastPage}
+                    >
+                      Next
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            )}
+          </div>
         </>
       ) : (
         <div>No related Properties</div>

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -77,43 +77,86 @@ const PropertySection = ({ property, active }) => {
         </div>
       </div>
       {open && (
-        <div
-          style={{
-            height: "auto",
-            padding: "12px 24px",
-            borderBottom: "1px solid #ccc",
-            background: "#78838f",
-            color: "white",
-          }}
-        >
+        <div className="property-details">
           {proprietor_category_1 && (
             <>
-              <p>Property Address: {property_address}</p>
-              <p>Proprietor Category: {proprietor_category_1}</p>
-              <p>Proprietor Name: {proprietor_name_1}</p>
-              <p>Proprietor Address: {proprietor_1_address_1}</p>
-              <p>Tenure: {tenure}</p>
-              <p>Date Proprietor Added: {date_proprietor_added}</p>
-              <span className="horizontal-divider" />
+              <div className="property-details-title">{property_address}</div>
+              <div className="property-details-section">
+                <div className="Property-details-section__title">
+                  Proprietor Name:
+                </div>
+                <div className="Property-details-section__value">
+                  {proprietor_name_1}
+                </div>
+              </div>
+              <div className="property-details-section">
+                <div className="Property-details-section__title">
+                  Proprietor Address:
+                </div>
+                <div className="Property-details-section__value">
+                  {proprietor_1_address_1}
+                </div>
+              </div>
+              <div className="property-details-section">
+                <div className="property-details-section__inner">
+                  <div className="Property-details-section__title">
+                    Proprietor Category:
+                  </div>
+                  <div className="Property-details-section__value">
+                    {proprietor_category_1}
+                  </div>
+                </div>
+                <div className="property-details-section__inner">
+                  <div className="Property-details-section__title">Tenure:</div>
+                  <div className="Property-details-section__value">
+                    {tenure}
+                  </div>
+                </div>
+                <div className="property-details-section__inner">
+                  <div className="Property-details-section__title">
+                    Date Proprietor Added:
+                  </div>
+                  <div className="Property-details-section__value">
+                    {date_proprietor_added}
+                  </div>
+                </div>
+              </div>
             </>
           )}
-          <p title="The Title Register gives information on who owns the property or land, and any rights of way">
-            <b>INSPIRE ID:</b> {poly_id}
-          </p>
-          <p title="The Title Plan includes the property or land's location and boundaries">
-            <b>Title number:</b> {title_no}
-          </p>
-          <p>
-            You can access these documents for a small fee by visiting the{" "}
-            <a
-              href="https://search-property-information.service.gov.uk/search/search-by-inspire-id"
-              target="_blank"
-              rel="noopener noreferrer"
+          <div className="property-details-section">
+            <div className="property-details-section__inner">
+              <div
+                className="Property-details-section__title"
+                title="The Title Register gives information on who owns the property or land, and any rights of way"
+              >
+                INSPIRE ID:
+              </div>
+              <div className="Property-details-section__value">{poly_id}</div>
+            </div>
+            <div
+              className="property-details-section__inner"
+              title="The Title Plan includes the property or land's location and boundaries"
             >
-              Land Registry website
-            </a>{" "}
-            using the above IDs.
-          </p>
+              <div className="Property-details-section__title">
+                Title Number:
+              </div>
+              <div className="Property-details-section__value">{title_no}</div>
+            </div>
+            <div className="property-details-section__small-print">
+              <p>
+                You can access these documents for a small fee by visiting the{" "}
+                <a
+                  href="https://search-property-information.service.gov.uk/search/search-by-inspire-id"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Land Registry website
+                </a>{" "}
+                using the above IDs.
+              </p>
+            </div>
+          </div>
+
           <button
             onClick={() =>
               dispatch({
@@ -124,7 +167,6 @@ const PropertySection = ({ property, active }) => {
           >
             Clear property
           </button>
-
           <div className="check-for-properties">
             <Button
               buttonClass={"button-new"}

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -1,9 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setActiveProperty } from "../../actions/LandOwnershipActions";
-import axios from "axios";
-import constants from "../../constants";
-import { getAuthHeader } from "../../utils/Auth";
 import Button from "../common/Button";
 import { getRelatedProperties } from "../../actions/LandOwnershipActions";
 
@@ -12,23 +9,6 @@ const PropertySection = ({ property }) => {
   const activePropertyId = useSelector(
     (state) => state.landOwnership.activePropertyId
   );
-
-  // const getOtherProperties = async () => {
-  //   try {
-  //     const response = await axios.get(
-  //       `${constants.ROOT_URL}/api/search?proprietorName=${proprietor_name_1}`,
-  //       getAuthHeader()
-  //     );
-
-  //     if (response.data.length > 0) {
-  //       console.log(response.data);
-  //     } else {
-  //       console.log("No properties found");
-  //     }
-  //   } catch (error) {
-  //     console.error("Error fetching properties:", error.message);
-  //   }
-  // };
 
   const {
     poly_id,
@@ -135,13 +115,6 @@ const PropertySection = ({ property }) => {
           </button>
 
           <div className="check-for-properties">
-            {/* <Button
-              buttonClass={"button-new"}
-              type={"button"}
-              buttonAction={getOtherProperties}
-            >
-              Check for other properties
-            </Button> */}
             <Button
               buttonClass={"button-new"}
               type={"button"}

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import constants from "../../constants";
 import { getAuthHeader } from "../../utils/Auth";
 import Button from "../common/Button";
+import { getRelatedProperties } from "../../actions/LandOwnershipActions";
 
 const PropertySection = ({ property }) => {
   const dispatch = useDispatch();
@@ -12,22 +13,22 @@ const PropertySection = ({ property }) => {
     (state) => state.landOwnership.activePropertyId
   );
 
-  const getOtherProperties = async () => {
-    try {
-      const response = await axios.get(
-        `${constants.ROOT_URL}/api/search?proprietorName=${proprietor_name_1}`,
-        getAuthHeader()
-      );
+  // const getOtherProperties = async () => {
+  //   try {
+  //     const response = await axios.get(
+  //       `${constants.ROOT_URL}/api/search?proprietorName=${proprietor_name_1}`,
+  //       getAuthHeader()
+  //     );
 
-      if (response.data.length > 0) {
-        console.log(response.data);
-      } else {
-        console.log("No properties found");
-      }
-    } catch (error) {
-      console.error("Error fetching properties:", error.message);
-    }
-  };
+  //     if (response.data.length > 0) {
+  //       console.log(response.data);
+  //     } else {
+  //       console.log("No properties found");
+  //     }
+  //   } catch (error) {
+  //     console.error("Error fetching properties:", error.message);
+  //   }
+  // };
 
   const {
     poly_id,
@@ -134,10 +135,19 @@ const PropertySection = ({ property }) => {
           </button>
 
           <div className="check-for-properties">
-            <Button
+            {/* <Button
               buttonClass={"button-new"}
               type={"button"}
               buttonAction={getOtherProperties}
+            >
+              Check for other properties
+            </Button> */}
+            <Button
+              buttonClass={"button-new"}
+              type={"button"}
+              buttonAction={() =>
+                dispatch(getRelatedProperties(proprietor_name_1))
+              }
             >
               Check for other properties
             </Button>

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -1,86 +1,145 @@
-import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { setActiveProperty } from "../../actions/LandOwnershipActions";
+import axios from "axios";
+import constants from "../../constants";
+import { getAuthHeader } from "../../utils/Auth";
+import Button from "../common/Button";
 
 const PropertySection = ({ property }) => {
-    const dispatch = useDispatch();
-    const activePropertyId = useSelector(state => state.landOwnership.activePropertyId);
+  const dispatch = useDispatch();
+  const activePropertyId = useSelector(
+    (state) => state.landOwnership.activePropertyId
+  );
 
-    const {
-        poly_id,
-        title_no,
-        proprietor_category_1,
-        property_address,
-        proprietor_name_1,
-        proprietor_1_address_1,
-        tenure,
-        date_proprietor_added
-    } = property;
+  const getOtherProperties = async () => {
+    const response = await axios.get(
+      `${constants.ROOT_URL}/api/search?proprietorName=` + proprietor_name_1,
+      getAuthHeader()
+    );
+    const properties = response.data.map((property) => {
+      const json = JSON.parse(property.proprietor_name_1);
+      return {
+        ...property,
+      };
+    });
 
-    const open = poly_id === activePropertyId;
+    if (properties.length > 0) console.log(properties);
+  };
 
-    return <div className="left-pane-tray-section">
-        <div className="left-pane-tray-section-title property-section"
-            onClick={() => {
-                if (open) {
-                    dispatch({ type: 'CLEAR_ACTIVE_PROPERTY' });
-                } else {
-                    dispatch(setActiveProperty(poly_id));
-                }
-            }}
+  const {
+    poly_id,
+    title_no,
+    proprietor_category_1,
+    property_address,
+    proprietor_name_1,
+    proprietor_1_address_1,
+    tenure,
+    date_proprietor_added,
+  } = property;
+
+  const open = poly_id === activePropertyId;
+
+  return (
+    <div className="left-pane-tray-section">
+      <div
+        className="left-pane-tray-section-title property-section"
+        onClick={() => {
+          if (open) {
+            dispatch({ type: "CLEAR_ACTIVE_PROPERTY" });
+          } else {
+            dispatch(setActiveProperty(poly_id));
+          }
+        }}
+      >
+        <h4
+          style={{
+            marginLeft: "48px",
+            fontWeight: "bold",
+            width: "140px",
+          }}
         >
-            <h4 style={{
-                marginLeft: '48px',
-                fontWeight: 'bold',
-                width: '140px'
-            }}>Property {poly_id}</h4>
-            <div style={{
-                position: 'absolute',
-                top: '50%',
-                transform: 'translateY(-50%)',
-                right: '12px',
-                width: '24px',
-                height: '24px',
-                textAlign: 'center'
-            }}>
-                <img
-                    src={require('../../assets/img/icon-chevron.svg')} alt=""
-                    style={{
-                        transformOrigin: 'center',
-                        transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
-                    }}
-                />
-            </div>
-        </div>
-        {open && <div
+          Property {poly_id}
+        </h4>
+        <div
+          style={{
+            position: "absolute",
+            top: "50%",
+            transform: "translateY(-50%)",
+            right: "12px",
+            width: "24px",
+            height: "24px",
+            textAlign: "center",
+          }}
+        >
+          <img
+            src={require("../../assets/img/icon-chevron.svg")}
+            alt=""
             style={{
-                height: 'auto',
-                padding: '12px 24px',
-                borderBottom: '1px solid #ccc',
-                background: '#78838f',
-                color: 'white'
-            }}>
-            {
-                proprietor_category_1 && <>
-                    <p>Property Address: {property_address}</p>
-                    <p>Proprietor Category: {proprietor_category_1}</p>
-                    <p>Proprietor Name: {proprietor_name_1}</p>
-                    <p>Proprietor Address: {proprietor_1_address_1}</p>
-                    <p>Tenure: {tenure}</p>
-                    <p>Date Proprietor Added: {date_proprietor_added}</p>
-                    <span className="horizontal-divider" />
-                </>
-            }
-            <p title="The Title Register gives information on who owns the property or land, and any rights of way"><b>INSPIRE ID:</b> {poly_id}</p>
-            <p title="The Title Plan includes the property or land's location and boundaries"><b>Title number:</b> {title_no}</p>
-            <p>You can access these documents for a small fee by visiting the <a href="https://search-property-information.service.gov.uk/search/search-by-inspire-id" target="_blank" rel="noopener noreferrer">Land Registry website</a> using the above IDs.</p>
-            <button onClick={() => dispatch({
-                type: "CLEAR_HIGHLIGHT",
-                payload: property
-            })}>Clear property</button>
+              transformOrigin: "center",
+              transform: open ? "rotate(180deg)" : "rotate(0deg)",
+            }}
+          />
         </div>
-        }
+      </div>
+      {open && (
+        <div
+          style={{
+            height: "auto",
+            padding: "12px 24px",
+            borderBottom: "1px solid #ccc",
+            background: "#78838f",
+            color: "white",
+          }}
+        >
+          {proprietor_category_1 && (
+            <>
+              <p>Property Address: {property_address}</p>
+              <p>Proprietor Category: {proprietor_category_1}</p>
+              <p>Proprietor Name: {proprietor_name_1}</p>
+              <p>Proprietor Address: {proprietor_1_address_1}</p>
+              <p>Tenure: {tenure}</p>
+              <p>Date Proprietor Added: {date_proprietor_added}</p>
+              <span className="horizontal-divider" />
+            </>
+          )}
+          <p title="The Title Register gives information on who owns the property or land, and any rights of way">
+            <b>INSPIRE ID:</b> {poly_id}
+          </p>
+          <p title="The Title Plan includes the property or land's location and boundaries">
+            <b>Title number:</b> {title_no}
+          </p>
+          <p>
+            You can access these documents for a small fee by visiting the{" "}
+            <a
+              href="https://search-property-information.service.gov.uk/search/search-by-inspire-id"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Land Registry website
+            </a>{" "}
+            using the above IDs.
+          </p>
+          <button
+            onClick={() =>
+              dispatch({
+                type: "CLEAR_HIGHLIGHT",
+                payload: property,
+              })
+            }
+          >
+            Clear property
+          </button>
+
+          <div className="check-for-properties">
+            <Button type={button} buttonAction={getOtherProperties}>
+              Check for other properties
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
-}
+  );
+};
 
 export default PropertySection;

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { setActiveProperty } from "../../actions/LandOwnershipActions";
 import Button from "../common/Button";
 import { getRelatedProperties } from "../../actions/LandOwnershipActions";
-import { isMobile } from "react-device-detect";
 
 const PropertySection = ({ property, active }) => {
   const dispatch = useDispatch();

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -13,18 +13,20 @@ const PropertySection = ({ property }) => {
   );
 
   const getOtherProperties = async () => {
-    const response = await axios.get(
-      `${constants.ROOT_URL}/api/search?proprietorName=` + proprietor_name_1,
-      getAuthHeader()
-    );
-    const properties = response.data.map((property) => {
-      const json = JSON.parse(property.proprietor_name_1);
-      return {
-        ...property,
-      };
-    });
+    try {
+      const response = await axios.get(
+        `${constants.ROOT_URL}/api/search?proprietorName=${proprietor_name_1}`,
+        getAuthHeader()
+      );
 
-    if (properties.length > 0) console.log(properties);
+      if (response.data.length > 0) {
+        console.log(response.data);
+      } else {
+        console.log("No properties found");
+      }
+    } catch (error) {
+      console.error("Error fetching properties:", error.message);
+    }
   };
 
   const {
@@ -132,7 +134,11 @@ const PropertySection = ({ property }) => {
           </button>
 
           <div className="check-for-properties">
-            <Button type={button} buttonAction={getOtherProperties}>
+            <Button
+              buttonClass={"button-new"}
+              type={"button"}
+              buttonAction={getOtherProperties}
+            >
               Check for other properties
             </Button>
           </div>

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -30,6 +30,7 @@ const PropertySection = ({ property, active }) => {
   };
 
   const handleSearch = () => {
+    dispatch({ type: "CLEAR_PROPERTIES" });
     dispatch(getRelatedProperties(proprietor_name_1));
     openTray("Ownership Search");
   };
@@ -82,41 +83,41 @@ const PropertySection = ({ property, active }) => {
             <>
               <div className="property-details-title">{property_address}</div>
               <div className="property-details-section">
-                <div className="Property-details-section__title">
+                <div className="property-details-section__title">
                   Proprietor Name:
                 </div>
-                <div className="Property-details-section__value">
+                <div className="property-details-section__value">
                   {proprietor_name_1}
                 </div>
               </div>
               <div className="property-details-section">
-                <div className="Property-details-section__title">
+                <div className="property-details-section__title">
                   Proprietor Address:
                 </div>
-                <div className="Property-details-section__value">
+                <div className="property-details-section__value">
                   {proprietor_1_address_1}
                 </div>
               </div>
               <div className="property-details-section">
                 <div className="property-details-section__inner">
-                  <div className="Property-details-section__title">
+                  <div className="property-details-section__title">
                     Proprietor Category:
                   </div>
-                  <div className="Property-details-section__value">
+                  <div className="property-details-section__value">
                     {proprietor_category_1}
                   </div>
                 </div>
                 <div className="property-details-section__inner">
-                  <div className="Property-details-section__title">Tenure:</div>
-                  <div className="Property-details-section__value">
+                  <div className="property-details-section__title">Tenure:</div>
+                  <div className="property-details-section__value">
                     {tenure}
                   </div>
                 </div>
                 <div className="property-details-section__inner">
-                  <div className="Property-details-section__title">
+                  <div className="property-details-section__title">
                     Date Proprietor Added:
                   </div>
-                  <div className="Property-details-section__value">
+                  <div className="property-details-section__value">
                     {date_proprietor_added}
                   </div>
                 </div>
@@ -126,21 +127,21 @@ const PropertySection = ({ property, active }) => {
           <div className="property-details-section">
             <div className="property-details-section__inner">
               <div
-                className="Property-details-section__title"
+                className="property-details-section__title"
                 title="The Title Register gives information on who owns the property or land, and any rights of way"
               >
                 INSPIRE ID:
               </div>
-              <div className="Property-details-section__value">{poly_id}</div>
+              <div className="property-details-section__value">{poly_id}</div>
             </div>
             <div
               className="property-details-section__inner"
               title="The Title Plan includes the property or land's location and boundaries"
             >
-              <div className="Property-details-section__title">
+              <div className="property-details-section__title">
                 Title Number:
               </div>
-              <div className="Property-details-section__value">{title_no}</div>
+              <div className="property-details-section__value">{title_no}</div>
             </div>
             <div className="property-details-section__small-print">
               <p>

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -3,8 +3,9 @@ import { useDispatch, useSelector } from "react-redux";
 import { setActiveProperty } from "../../actions/LandOwnershipActions";
 import Button from "../common/Button";
 import { getRelatedProperties } from "../../actions/LandOwnershipActions";
+import { isMobile } from "react-device-detect";
 
-const PropertySection = ({ property }) => {
+const PropertySection = ({ property, active }) => {
   const dispatch = useDispatch();
   const activePropertyId = useSelector(
     (state) => state.landOwnership.activePropertyId
@@ -22,6 +23,17 @@ const PropertySection = ({ property }) => {
   } = property;
 
   const open = poly_id === activePropertyId;
+
+  const openTray = (tray) => {
+    active === tray
+      ? dispatch({ type: "CLOSE_TRAY" })
+      : dispatch({ type: "SET_ACTIVE", payload: tray });
+  };
+
+  const handleSearch = () => {
+    dispatch(getRelatedProperties(proprietor_name_1));
+    openTray("Ownership Search");
+  };
 
   return (
     <div className="left-pane-tray-section">
@@ -118,9 +130,7 @@ const PropertySection = ({ property }) => {
             <Button
               buttonClass={"button-new"}
               type={"button"}
-              buttonAction={() =>
-                dispatch(getRelatedProperties(proprietor_name_1))
-              }
+              buttonAction={handleSearch}
             >
               Check for other properties
             </Button>

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -158,24 +158,27 @@ const PropertySection = ({ property, active }) => {
             </div>
           </div>
 
-          <button
-            onClick={() =>
-              dispatch({
-                type: "CLEAR_HIGHLIGHT",
-                payload: property,
-              })
-            }
-          >
-            Clear property
-          </button>
-          <div className="check-for-properties">
+          <div className="property__check-for-properties">
             <Button
-              buttonClass={"button-new"}
+              buttonClass={"button-new green full-width"}
               type={"button"}
               buttonAction={handleSearch}
             >
               Check for other properties
             </Button>
+          </div>
+          <div className="property__clear-property">
+            <button
+              className="button-new blue full-width"
+              onClick={() =>
+                dispatch({
+                  type: "CLEAR_HIGHLIGHT",
+                  payload: property,
+                })
+              }
+            >
+              Clear property
+            </button>
           </div>
         </div>
       )}

--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -1,0 +1,22 @@
+import React, { useEffect } from "react";
+
+const RelatedProperties = ({ properties, error, getRelatedProperties }) => {
+  useEffect(() => {
+    getRelatedProperties();
+  }, [getRelatedProperties]);
+
+  return (
+    <div>
+      {error && <p>{error}</p>}
+      {properties.length > 0 && (
+        <ul>
+          {properties.map((property) => (
+            <li key={property.title_no}>{property.property_address}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default RelatedProperties;

--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -1,8 +1,22 @@
 import React from "react";
+import { useDispatch } from "react-redux";
+import { showPropertyPolygon } from "../../actions/LandOwnershipActions";
 
 const RelatedProperties = ({ property }) => {
+  const dispatch = useDispatch();
+
+  const handlePropertyClick = () => {
+    dispatch(showPropertyPolygon(property.geom.coordinates[0]));
+    console.log("Property clicked", property.geom.coordinates);
+    console.log("title_no", property.title_no);
+  };
+
   return (
-    <div className="search-result" key={property.title_no}>
+    <div
+      className="search-result"
+      key={property.title_no}
+      onClick={handlePropertyClick}
+    >
       <i>
         <svg
           className="icon-property"
@@ -16,7 +30,9 @@ const RelatedProperties = ({ property }) => {
         </svg>
       </i>
       <div className="search-result__property">
-        <h4 className="search-result__property-address">{property.property_address}</h4>
+        <h4 className="search-result__property-address">
+          {property.property_address}
+        </h4>
         <div className="search-result__title-no">
           Title no: {property.title_no}
         </div>

--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -1,12 +1,42 @@
 import React from "react";
 
 const RelatedProperties = ({ property }) => {
-
   return (
-    <div className="relatedProperty" key={property.title_no}>
-        <h4>{property.property_address}</h4>
-        <p>{property.proprietor_name_1}</p>
-        <p>{property.title_no}</p>
+    <div className="search-result" key={property.title_no}>
+      <i>
+        <svg
+          className="icon-property"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 12.6 18"
+        >
+          <path
+            d="M13.8,3A6.3,6.3,0,0,0,7.5,9.3c0,4.725,6.3,11.7,6.3,11.7s6.3-6.975,6.3-11.7A6.3,6.3,0,0,0,13.8,3Zm0,8.55A2.25,2.25,0,1,1,16.05,9.3,2.251,2.251,0,0,1,13.8,11.55Z"
+            transform="translate(-7.5 -3)"
+          />
+        </svg>
+      </i>
+      <div className="search-result__property">
+        <h4 className="search-result__property-address">{property.property_address}</h4>
+        <div className="search-result__title-no">
+          Title no: {property.title_no}
+        </div>
+      </div>
+
+      {/* <div className="search-result__proprietor">
+        <i>
+          <svg
+            className="icon-proprietor"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 18 18"
+          >
+            <path
+              d="M15,15a4.5,4.5,0,1,0-4.5-4.5A4.5,4.5,0,0,0,15,15Zm0,2.25c-3,0-9,1.507-9,4.5V24H24V21.75C24,18.757,18,17.25,15,17.25Z"
+              transform="translate(-6 -6)"
+            />
+          </svg>
+        </i>
+        {property.proprietor_name_1}
+      </div> */}
     </div>
   );
 };

--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -1,15 +1,12 @@
 import React from "react";
 
 const RelatedProperties = ({ property }) => {
-  const { poly_id, title_no, property_address, proprietor_name_1 } = property;
 
   return (
-    <div className="relatedProperty">
-      <div key={property.title_no}>
+    <div className="relatedProperty" key={property.title_no}>
         <h4>{property.property_address}</h4>
         <p>{property.proprietor_name_1}</p>
         <p>{property.title_no}</p>
-      </div>
     </div>
   );
 };

--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -1,18 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { showPropertyPolygon } from "../../actions/LandOwnershipActions";
+import { setLngLat } from "../../actions/MapActions";
 
 const RelatedProperties = ({ property }) => {
   const dispatch = useDispatch();
+  const [active, setActive] = useState(false);
+
+  const lng = property.geom.coordinates[0][0][1];
+  const lat = property.geom.coordinates[0][0][0];
 
   const handlePropertyClick = () => {
+    dispatch(setLngLat(lng, lat));
     dispatch(showPropertyPolygon(property.geom.coordinates[0]));
     console.log("Property clicked", property.geom.coordinates);
     console.log("title_no", property.title_no);
+    console.log("lat", lat);
+    console.log("lng", lng);
+    // setActive(!active);
   };
 
   return (
     <div
+      // className={`search-result ${active ? 'active' : ''}`}
       className="search-result"
       key={property.title_no}
       onClick={handlePropertyClick}

--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -1,20 +1,15 @@
-import React, { useEffect } from "react";
+import React from "react";
 
-const RelatedProperties = ({ properties, error, getRelatedProperties }) => {
-  useEffect(() => {
-    getRelatedProperties();
-  }, [getRelatedProperties]);
+const RelatedProperties = ({ property }) => {
+  const { poly_id, title_no, property_address, proprietor_name_1 } = property;
 
   return (
-    <div>
-      {error && <p>{error}</p>}
-      {properties.length > 0 && (
-        <ul>
-          {properties.map((property) => (
-            <li key={property.title_no}>{property.property_address}</li>
-          ))}
-        </ul>
-      )}
+    <div className="relatedProperty">
+      <div key={property.title_no}>
+        <h4>{property.property_address}</h4>
+        <p>{property.proprietor_name_1}</p>
+        <p>{property.title_no}</p>
+      </div>
     </div>
   );
 };

--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -3,67 +3,72 @@ import { useDispatch } from "react-redux";
 import { showPropertyPolygon } from "../../actions/LandOwnershipActions";
 import { setLngLat } from "../../actions/MapActions";
 
-const RelatedProperties = ({ property }) => {
+const RelatedProperties = ({ property, isActive, onPropertyClick }) => {
   const dispatch = useDispatch();
-  const [active, setActive] = useState(false);
 
   const lng = property.geom.coordinates[0][0][1];
   const lat = property.geom.coordinates[0][0][0];
 
   const handlePropertyClick = () => {
+    onPropertyClick();
     dispatch(setLngLat(lng, lat));
     dispatch(showPropertyPolygon(property.geom.coordinates[0]));
-    console.log("Property clicked", property.geom.coordinates);
-    console.log("title_no", property.title_no);
-    console.log("lat", lat);
-    console.log("lng", lng);
-    // setActive(!active);
   };
 
   return (
-    <div
-      // className={`search-result ${active ? 'active' : ''}`}
-      className="search-result"
-      key={property.title_no}
-      onClick={handlePropertyClick}
-    >
-      <i>
-        <svg
-          className="icon-property"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 12.6 18"
-        >
-          <path
-            d="M13.8,3A6.3,6.3,0,0,0,7.5,9.3c0,4.725,6.3,11.7,6.3,11.7s6.3-6.975,6.3-11.7A6.3,6.3,0,0,0,13.8,3Zm0,8.55A2.25,2.25,0,1,1,16.05,9.3,2.251,2.251,0,0,1,13.8,11.55Z"
-            transform="translate(-7.5 -3)"
-          />
-        </svg>
-      </i>
-      <div className="search-result__property">
-        <h4 className="search-result__property-address">
-          {property.property_address}
-        </h4>
-        <div className="search-result__title-no">
-          Title no: {property.title_no}
+    <>
+      {isActive ? (
+        <div className="search-result active" key={property.title_no}>
+          <i>
+            <svg
+              className="icon-property"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 12.6 18"
+            >
+              <path
+                d="M13.8,3A6.3,6.3,0,0,0,7.5,9.3c0,4.725,6.3,11.7,6.3,11.7s6.3-6.975,6.3-11.7A6.3,6.3,0,0,0,13.8,3Zm0,8.55A2.25,2.25,0,1,1,16.05,9.3,2.251,2.251,0,0,1,13.8,11.55Z"
+                transform="translate(-7.5 -3)"
+              />
+            </svg>
+          </i>
+          <div className="search-result__property">
+            <h4 className="search-result__property-address">
+              {property.property_address}
+            </h4>
+            <div className="search-result__title-no">
+              Title no: {property.title_no}
+            </div>
+          </div>
         </div>
-      </div>
-
-      {/* <div className="search-result__proprietor">
-        <i>
-          <svg
-            className="icon-proprietor"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 18 18"
-          >
-            <path
-              d="M15,15a4.5,4.5,0,1,0-4.5-4.5A4.5,4.5,0,0,0,15,15Zm0,2.25c-3,0-9,1.507-9,4.5V24H24V21.75C24,18.757,18,17.25,15,17.25Z"
-              transform="translate(-6 -6)"
-            />
-          </svg>
-        </i>
-        {property.proprietor_name_1}
-      </div> */}
-    </div>
+      ) : (
+        <div
+          className="search-result"
+          key={property.title_no}
+          onClick={handlePropertyClick}
+        >
+          <i>
+            <svg
+              className="icon-property"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 12.6 18"
+            >
+              <path
+                d="M13.8,3A6.3,6.3,0,0,0,7.5,9.3c0,4.725,6.3,11.7,6.3,11.7s6.3-6.975,6.3-11.7A6.3,6.3,0,0,0,13.8,3Zm0,8.55A2.25,2.25,0,1,1,16.05,9.3,2.251,2.251,0,0,1,13.8,11.55Z"
+                transform="translate(-7.5 -3)"
+              />
+            </svg>
+          </i>
+          <div className="search-result__property">
+            <h4 className="search-result__property-address">
+              {property.property_address}
+            </h4>
+            <div className="search-result__title-no">
+              Title no: {property.title_no}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/map/MapProperties.js
+++ b/src/components/map/MapProperties.js
@@ -16,6 +16,7 @@ const MapProperties = ({ center, map }) => {
   const highlightedProperties = useSelector(state => state.landOwnership.highlightedProperties);
   const activePropertyId = useSelector(state => state.landOwnership.activePropertyId);
   const activeProperty = activePropertyId !== null ? highlightedProperties.find(p => p.poly_id === activePropertyId) : null;
+  
 
   const activePanel = useSelector(state => state.leftPane.active);
 

--- a/src/components/map/MapboxMap.js
+++ b/src/components/map/MapboxMap.js
@@ -286,9 +286,6 @@ const MapboxMap = ({ user }) => {
         // this is how the map moves automatically from one location to another (default is jumpTo, but we disable this temporarily when we load a new map)
         movingMethod={movingMethod}
       >
-        {/* Property Search Poly / No clue where this should go */}
-        {propertyCoordinates.length > 0 && <PropertySearchPoly />}
-
         {/* Map Layers (greenbelt etc.)*/}
         <MapLayers />
         {/* Map Data Groups displaying My Data, except data group markers, which are in Markers to cluster together */}
@@ -301,6 +298,10 @@ const MapboxMap = ({ user }) => {
             setDataGroupPopupVisible(markerId);
           }}
         />
+        {/* Property Search Poly / No clue where this should go */}
+        {propertyCoordinates.length > 0 && (
+          <PropertySearchPoly />
+        )}
         {/*For displaying the property boundaries*/}
         {constants.LR_POLYGONS_ENABLED && (
           <MapProperties center={lngLat} map={map} />

--- a/src/components/map/MapboxMap.js
+++ b/src/components/map/MapboxMap.js
@@ -18,6 +18,7 @@ import mapSources from "../../data/mapSources";
 import MapProperties from "./MapProperties";
 import MapDataGroups from "./MapDataGroups";
 import { autoSave, setLngLat, setZoom } from "../../actions/MapActions";
+import PropertySearchPoly from "./PropertySearchPoly";
 
 // Create Map Component with settings
 const Map = ReactMapboxGl({
@@ -46,6 +47,20 @@ const MapboxMap = ({ user }) => {
   const propertiesDisplay = useSelector(
     (state) => state.landOwnership.displayActive
   );
+  const propertyCoordinates = useSelector(
+    (state) => state.propertySearchPoly.propertyCoordinates
+  );
+
+  // Check the propertyCoordinates update propagates to the MapboxMap component
+  useEffect(() => {
+    if (propertyCoordinates.length > 0) {
+      console.log(
+        "Property coordinates exist - MapboxMap",
+        propertyCoordinates
+      );
+    }
+  }, [propertyCoordinates]);
+
   const [styleLoaded, setStyleLoaded] = useState(false);
   const [drawings, setDrawings] = useState();
   const [redrawing, setRedrawing] = useState(false);
@@ -271,6 +286,9 @@ const MapboxMap = ({ user }) => {
         // this is how the map moves automatically from one location to another (default is jumpTo, but we disable this temporarily when we load a new map)
         movingMethod={movingMethod}
       >
+        {/* Property Search Poly / No clue where this should go */}
+        {propertyCoordinates.length > 0 && <PropertySearchPoly />}
+
         {/* Map Layers (greenbelt etc.)*/}
         <MapLayers />
         {/* Map Data Groups displaying My Data, except data group markers, which are in Markers to cluster together */}

--- a/src/components/map/PropertySearchPoly.js
+++ b/src/components/map/PropertySearchPoly.js
@@ -11,7 +11,7 @@ const PropertySearchPoly = ({ property }) => {
 
   const polygonData = {
     geometry: {
-      coordinates: propertyCoordinates.map((coord) => coord.reverse()),
+      coordinates: [propertyCoordinates.map((coord) => coord.reverse())],
       type: "Polygon",
     },
     id: polyId,

--- a/src/components/map/PropertySearchPoly.js
+++ b/src/components/map/PropertySearchPoly.js
@@ -11,7 +11,7 @@ const PropertySearchPoly = ({ property }) => {
 
   const polygonData = {
     geometry: {
-      coordinates: propertyCoordinates,
+      coordinates: propertyCoordinates.map((coord) => coord.reverse()),
       type: "Polygon",
     },
     id: polyId,

--- a/src/components/map/PropertySearchPoly.js
+++ b/src/components/map/PropertySearchPoly.js
@@ -1,0 +1,52 @@
+import React, { useEffect } from "react";
+import { useSelector } from "react-redux";
+import { GeoJSONLayer } from "react-mapbox-gl";
+
+const PropertySearchPoly = ({ property }) => {
+  const propertyCoordinates = useSelector(
+    (state) => state.propertySearchPoly.propertyCoordinates
+  );
+
+  const polyId = useSelector((state) => state.propertySearchPoly.polyId);
+
+  const polygonData = {
+    geometry: {
+      coordinates: propertyCoordinates,
+      type: "Polygon",
+    },
+    id: polyId,
+    properties: {},
+    type: "Feature",
+  };
+
+  const polygonLayer = (
+    <GeoJSONLayer
+      key={polyId}
+      data={polygonData}
+      linePaint={{
+        "line-color": "red",
+        "line-width": 2,
+        "line-opacity": 1,
+      }}
+      fillPaint={{
+        "fill-color": "red",
+        "fill-opacity": 0.3,
+      }}
+    />
+  );
+
+  useEffect(() => {
+    console.log("Property coordinates exist!", propertyCoordinates, polyId);
+    console.log("Polygon Layer", polygonLayer);
+  }, [propertyCoordinates, polyId]);
+
+  // Check if propertyCoordinates exist before rendering GeoJSONLayer
+  if (!propertyCoordinates || propertyCoordinates.length === 0) {
+    console.log("Property coordinates do not exist!");
+    return null;
+  }
+
+  return <>{polygonLayer}</>;
+};
+
+export default PropertySearchPoly;

--- a/src/reducers/RelatedPropertiesReducer.js
+++ b/src/reducers/RelatedPropertiesReducer.js
@@ -1,0 +1,23 @@
+const INITIAL_STATE = {
+  properties: [],
+  error: null,
+};
+
+export default (state = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case "FETCH_PROPERTIES_SUCCESS":
+      return {
+        ...state,
+        properties: action.payload,
+        error: null,
+      };
+    case "FETCH_PROPERTIES_FAILURE":
+      return {
+        ...state,
+        properties: [],
+        error: action.payload,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/reducers/RelatedPropertiesReducer.js
+++ b/src/reducers/RelatedPropertiesReducer.js
@@ -17,6 +17,8 @@ export default (state = INITIAL_STATE, action) => {
         properties: [],
         error: action.payload,
       };
+    case "CLEAR_PROPERTIES":
+      return INITIAL_STATE;
     default:
       return state;
   }

--- a/src/reducers/RelatedPropertiesReducer.js
+++ b/src/reducers/RelatedPropertiesReducer.js
@@ -1,6 +1,7 @@
 const INITIAL_STATE = {
   properties: [],
   error: null,
+  loading: false,
 };
 
 export default (state = INITIAL_STATE, action) => {
@@ -10,12 +11,19 @@ export default (state = INITIAL_STATE, action) => {
         ...state,
         properties: action.payload,
         error: null,
+        loading: false,
       };
     case "FETCH_PROPERTIES_FAILURE":
       return {
         ...state,
         properties: [],
         error: action.payload,
+        loading: false,
+      };
+    case "FETCH_PROPERTIES_LOADING":
+      return {
+        ...state,
+        loading: true,
       };
     case "CLEAR_PROPERTIES":
       return INITIAL_STATE;

--- a/src/reducers/ShowPropertyPolyReducer.js
+++ b/src/reducers/ShowPropertyPolyReducer.js
@@ -1,0 +1,19 @@
+import { SHOW_PROPERTY_POLYGON } from "../actions/LandOwnershipActions";
+
+const INITIAL_STATE = {
+  propertyCoordinates: [],
+  polyId: null,
+};
+
+export default (state = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case SHOW_PROPERTY_POLYGON:
+      return {
+        ...state,
+        propertyCoordinates: action.payload,
+        polyId: action.payload.poly_id,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -19,6 +19,7 @@ import LandOwnershipReducer from "./LandOwnershipReducer";
 import DataGroupsReducer from "./DataGroupsReducer";
 import ConnectivityReducer from "./ConnectivityReducer";
 import RelatedPropertiesReducer from "./RelatedPropertiesReducer";
+import ShowPropertyPolyReducer from "./ShowPropertyPolyReducer";
 
 const appReducer = combineReducers({
   authentication: AuthenticationReducer,
@@ -41,6 +42,7 @@ const appReducer = combineReducers({
   dataGroups: DataGroupsReducer,
   connectivity: ConnectivityReducer,
   relatedProperties: RelatedPropertiesReducer,
+  propertySearchPoly: ShowPropertyPolyReducer,
 });
 
 const rootReducer = (state, action) => {

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -18,6 +18,7 @@ import MapMetaReducer from "./MapMetaReducer";
 import LandOwnershipReducer from "./LandOwnershipReducer";
 import DataGroupsReducer from "./DataGroupsReducer";
 import ConnectivityReducer from "./ConnectivityReducer";
+import RelatedPropertiesReducer from "./RelatedPropertiesReducer";
 
 const appReducer = combineReducers({
   authentication: AuthenticationReducer,
@@ -39,6 +40,7 @@ const appReducer = combineReducers({
   landOwnership: LandOwnershipReducer,
   dataGroups: DataGroupsReducer,
   connectivity: ConnectivityReducer,
+  relatedProperties: RelatedPropertiesReducer,
 });
 
 const rootReducer = (state, action) => {


### PR DESCRIPTION
Closes #256

### What?

The ability to search for a proprietor's other properties has been added to the property panel. A button now appears below the property details and above the clear property button.

Once the search has been initiated, the new **Ownership Search** panel opens and if applicable the proprietors other properties are listed.

These can be clicked, taking you to the relevant location on the map.

### Outstanding Bug
When a property listing within the **Ownership Search** panel is clicked, you are taken to the relevant highlighted polygon but the highlighting disappears when the **Land Registry** layer rerenders. However, once you interact with the map the highlighted poly reappears.
