### PR TITLE
261 backsearch only show the ownership icon when there is data to display

### DIFF
--- a/src/actions/LandOwnershipActions.js
+++ b/src/actions/LandOwnershipActions.js
@@ -1,7 +1,5 @@
 import { getRequest } from "./RequestActions";
 
-export const SHOW_PROPERTY_POLYGON = "SHOW_PROPERTY_POLYGON";
-
 export const highlightProperty = (property) => {
   return (dispatch) => {
     dispatch({
@@ -54,10 +52,17 @@ export const getRelatedProperties = (proprietorName) => {
   };
 };
 
+export const setProprietorName = (proprietorName) => {
+  return {
+    type: "SET_PROPRIETOR_NAME",
+    payload: proprietorName,
+  };
+};
+
 export const showPropertyPolygon = (propertyCoordinates) => {
   return (dispatch) => {
     dispatch({
-      type: SHOW_PROPERTY_POLYGON,
+      type: "SHOW_PROPERTY_POLYGON",
       payload: propertyCoordinates,
     });
   };

--- a/src/components/left-pane/LeftPane.js
+++ b/src/components/left-pane/LeftPane.js
@@ -18,6 +18,9 @@ const LeftPane = ({ drawControl }) => {
   const activePolygon = useSelector((state) => state.drawings.activePolygon);
   const zoom = useSelector((state) => state.map.zoom);
   const propertyBoundriesZoom = constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL;
+  const propertySearch = useSelector(
+    (state) => state.relatedProperties.properties
+  );
   const landOwnershipActive = useSelector(
     (state) => state.landOwnership.displayActive
   );
@@ -132,23 +135,26 @@ const LeftPane = ({ drawControl }) => {
           data-tip
           data-for="ttInfo"
         />
-        {/* display land ownership icon only if land ownship layer is active and zoomed-in to sufficient level */}
-        {zoom >= propertyBoundriesZoom && landOwnershipActive == true && (
-          <div
-            className={`left-pane-icon ownership ${
-              active === "Ownership Search" && "active"
-            }`}
-            onClick={() => {
-              analytics.event(
-                analytics._event.LEFT_PANE + " Ownership Search",
-                "Open"
-              );
-              clickIcon("Ownership Search");
-            }}
-            data-tip
-            data-for="ttRelatedProperties"
-          />
-        )}
+        {/* display land ownership icon only if land ownship layer is active,
+        zoomed-in to sufficient level and search is not empty */}
+        {zoom >= propertyBoundriesZoom &&
+          landOwnershipActive == true &&
+          propertySearch.length > 0 && (
+            <div
+              className={`left-pane-icon ownership ${
+                active === "Ownership Search" && "active"
+              }`}
+              onClick={() => {
+                analytics.event(
+                  analytics._event.LEFT_PANE + " Ownership Search",
+                  "Open"
+                );
+                clickIcon("Ownership Search");
+              }}
+              data-tip
+              data-for="ttRelatedProperties"
+            />
+          )}
       </div>
       {
         // If not read only, render drawing tools

--- a/src/components/left-pane/LeftPane.js
+++ b/src/components/left-pane/LeftPane.js
@@ -7,7 +7,6 @@ import LeftPaneRelatedProperties from "./LeftPaneRelatedProperties";
 import analytics from "../../analytics";
 import { autoSave } from "../../actions/MapActions";
 import { isMobile } from "react-device-detect";
-import constants from "../../constants";
 
 const LeftPane = ({ drawControl }) => {
   const dispatch = useDispatch();
@@ -16,13 +15,8 @@ const LeftPane = ({ drawControl }) => {
   const profileMenuOpen = useSelector((state) => state.menu.profile);
   const currentMarker = useSelector((state) => state.markers.currentMarker);
   const activePolygon = useSelector((state) => state.drawings.activePolygon);
-  const zoom = useSelector((state) => state.map.zoom);
-  const propertyBoundriesZoom = constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL;
   const propertySearch = useSelector(
     (state) => state.relatedProperties.properties
-  );
-  const landOwnershipActive = useSelector(
-    (state) => state.landOwnership.displayActive
   );
 
   const closeTray = () => {
@@ -135,26 +129,23 @@ const LeftPane = ({ drawControl }) => {
           data-tip
           data-for="ttInfo"
         />
-        {/* display land ownership icon only if land ownship layer is active,
-        zoomed-in to sufficient level and search is not empty */}
-        {zoom >= propertyBoundriesZoom &&
-          landOwnershipActive == true &&
-          propertySearch.length > 0 && (
-            <div
-              className={`left-pane-icon ownership ${
-                active === "Ownership Search" && "active"
-              }`}
-              onClick={() => {
-                analytics.event(
-                  analytics._event.LEFT_PANE + " Ownership Search",
-                  "Open"
-                );
-                clickIcon("Ownership Search");
-              }}
-              data-tip
-              data-for="ttRelatedProperties"
-            />
-          )}
+        {/* display land ownership icon only if search is not empty */}
+        {propertySearch.length > 0 && (
+          <div
+            className={`left-pane-icon ownership ${
+              active === "Ownership Search" && "active"
+            }`}
+            onClick={() => {
+              analytics.event(
+                analytics._event.LEFT_PANE + " Ownership Search",
+                "Open"
+              );
+              clickIcon("Ownership Search");
+            }}
+            data-tip
+            data-for="ttRelatedProperties"
+          />
+        )}
       </div>
       {
         // If not read only, render drawing tools

--- a/src/components/left-pane/LeftPane.js
+++ b/src/components/left-pane/LeftPane.js
@@ -7,6 +7,7 @@ import LeftPaneRelatedProperties from "./LeftPaneRelatedProperties";
 import analytics from "../../analytics";
 import { autoSave } from "../../actions/MapActions";
 import { isMobile } from "react-device-detect";
+import constants from "../../constants";
 
 const LeftPane = ({ drawControl }) => {
   const dispatch = useDispatch();
@@ -15,6 +16,11 @@ const LeftPane = ({ drawControl }) => {
   const profileMenuOpen = useSelector((state) => state.menu.profile);
   const currentMarker = useSelector((state) => state.markers.currentMarker);
   const activePolygon = useSelector((state) => state.drawings.activePolygon);
+  const zoom = useSelector((state) => state.map.zoom);
+  const propertyBoundriesZoom = constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL;
+  const landOwnershipActive = useSelector(
+    (state) => state.landOwnership.displayActive
+  );
 
   const closeTray = () => {
     dispatch({ type: "CLOSE_TRAY" });
@@ -126,22 +132,24 @@ const LeftPane = ({ drawControl }) => {
           data-tip
           data-for="ttInfo"
         />
-        <div
-          className={`left-pane-icon ownership ${
-            active === "Ownership Search" && "active"
-          }`}
-          onClick={() => {
-            analytics.event(
-              analytics._event.LEFT_PANE + " Ownership Search",
-              "Open"
-            );
-            clickIcon("Ownership Search");
-          }}
-          data-tip
-          data-for="ttRelatedProperties"
-        />
+        {/* display land ownership icon only if land ownship layer is active and zoomed-in to sufficient level */}
+        {zoom >= propertyBoundriesZoom && landOwnershipActive == true && (
+          <div
+            className={`left-pane-icon ownership ${
+              active === "Ownership Search" && "active"
+            }`}
+            onClick={() => {
+              analytics.event(
+                analytics._event.LEFT_PANE + " Ownership Search",
+                "Open"
+              );
+              clickIcon("Ownership Search");
+            }}
+            data-tip
+            data-for="ttRelatedProperties"
+          />
+        )}
       </div>
-
       {
         // If not read only, render drawing tools
         !readOnly && (

--- a/src/components/left-pane/PropertySection.js
+++ b/src/components/left-pane/PropertySection.js
@@ -2,12 +2,18 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setActiveProperty } from "../../actions/LandOwnershipActions";
 import Button from "../common/Button";
-import { getRelatedProperties } from "../../actions/LandOwnershipActions";
+import {
+  getRelatedProperties,
+  setProprietorName,
+} from "../../actions/LandOwnershipActions";
 
 const PropertySection = ({ property, active }) => {
   const dispatch = useDispatch();
   const activePropertyId = useSelector(
     (state) => state.landOwnership.activePropertyId
+  );
+  const proprietorName = useSelector(
+    (state) => state.relatedProperties.proprietorName
   );
 
   const {
@@ -30,9 +36,18 @@ const PropertySection = ({ property, active }) => {
   };
 
   const handleSearch = () => {
-    dispatch({ type: "CLEAR_PROPERTIES" });
+    dispatch({ type: "CLEAR_PROPERTIES_AND_PROPRIETOR_NAME" });
     dispatch(getRelatedProperties(proprietor_name_1));
+    dispatch(setProprietorName(proprietor_name_1));
     openTray("Ownership Search");
+  };
+
+  const handleClear = () => {
+    dispatch({ type: "CLEAR_HIGHLIGHT", payload: property });
+    // Clear properties if the property being cleared is the searched property
+    if (property.proprietor_name_1 === proprietorName) {
+      dispatch({ type: "CLEAR_PROPERTIES_AND_PROPRIETOR_NAME" });
+    }
   };
 
   return (
@@ -170,12 +185,7 @@ const PropertySection = ({ property, active }) => {
           <div className="property__clear-property">
             <button
               className="button-new blue full-width"
-              onClick={() =>
-                dispatch({
-                  type: "CLEAR_HIGHLIGHT",
-                  payload: property,
-                })
-              }
+              onClick={handleClear}
             >
               Clear property
             </button>

--- a/src/reducers/RelatedPropertiesReducer.js
+++ b/src/reducers/RelatedPropertiesReducer.js
@@ -2,6 +2,7 @@ const INITIAL_STATE = {
   properties: [],
   error: null,
   loading: false,
+  proprietorName: null,
 };
 
 export default (state = INITIAL_STATE, action) => {
@@ -26,7 +27,26 @@ export default (state = INITIAL_STATE, action) => {
         loading: true,
       };
     case "CLEAR_PROPERTIES":
-      return INITIAL_STATE;
+      return {
+        ...state,
+        properties: [],
+      };
+    case "SET_PROPRIETOR_NAME":
+      return {
+        ...state,
+        proprietorName: action.payload,
+      };
+    case "CLEAR_PROPRIETOR_NAME":
+      return {
+        ...state,
+        proprietorName: null,
+      };
+    case "CLEAR_PROPERTIES_AND_PROPRIETOR_NAME":
+      return {
+        ...state,
+        properties: [],
+        proprietorName: null,
+      };
     default:
       return state;
   }

--- a/src/reducers/ShowPropertyPolyReducer.js
+++ b/src/reducers/ShowPropertyPolyReducer.js
@@ -1,5 +1,3 @@
-import { SHOW_PROPERTY_POLYGON } from "../actions/LandOwnershipActions";
-
 const INITIAL_STATE = {
   propertyCoordinates: [],
   polyId: null,
@@ -7,7 +5,7 @@ const INITIAL_STATE = {
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
-    case SHOW_PROPERTY_POLYGON:
+    case "SHOW_PROPERTY_POLYGON":
       return {
         ...state,
         propertyCoordinates: action.payload,


### PR DESCRIPTION
#### What? Why?

Closes #261

Ownership Icon is no longer visible by default, it only appears when an ownership search has been initiated. It disappears when that search has been cleared.

I did initially add conditions relating to zoom level and the ownership layer being visible, but these are unnecessary if a check is made on whether the search is empty or not.

Search is also cleared when the property from which the search was initiated is cleared from the info panel, triggering the icon to disappear.


