### PR TITLE
Autosave ownership layer display

### DIFF
--- a/src/actions/LandOwnershipActions.js
+++ b/src/actions/LandOwnershipActions.js
@@ -1,4 +1,12 @@
 import { getRequest } from "./RequestActions";
+import { autoSave } from './MapActions';
+
+export const togglePropertyDisplay = () => {
+  return dispatch => {
+    dispatch({ type: "TOGGLE_PROPERTY_DISPLAY" });
+    return dispatch(autoSave());
+  };
+}
 
 export const highlightProperty = (property) => {
   return (dispatch) => {

--- a/src/actions/MapActions.js
+++ b/src/actions/MapActions.js
@@ -140,6 +140,7 @@ export const saveCurrentMap = (
       mapLayers: {
         landDataLayers: getState().mapLayers.landDataLayers,
         myDataLayers: getState().dataGroups.activeGroups,
+        ownershipDisplay: getState().landOwnership.displayActive,
       },
       version: VERSION,
       name: saveName,

--- a/src/components/left-pane/LeftPaneLandData.js
+++ b/src/components/left-pane/LeftPaneLandData.js
@@ -5,6 +5,7 @@ import LeftPaneToggle from "./LeftPaneToggle";
 import Draggable from "./Draggable";
 import LandDataLayerToggle from "./LandDataLayerToggle";
 import { toggleDataGroup } from "../../actions/DataGroupActions";
+import { togglePropertyDisplay } from "../../actions/LandOwnershipActions";
 
 const DataLayersContainer = ({ children, title }) => {
   const [expanded, setExpanded] = useState(true);
@@ -120,7 +121,7 @@ const LeftPaneLandData = ({ open, active, onClose }) => {
         <LeftPaneToggle
           title={"Property Boundaries"}
           on={landOwnershipActive}
-          onToggle={() => dispatch({ type: "TOGGLE_PROPERTY_DISPLAY" })}
+          onToggle={() => dispatch(togglePropertyDisplay())}
         />
       </DataLayersContainer>
       <DataLayersContainer title={"Administrative Boundaries"}>

--- a/src/reducers/LandOwnershipReducer.js
+++ b/src/reducers/LandOwnershipReducer.js
@@ -50,6 +50,13 @@ export default (state = INITIAL_STATE, action) => {
         ...state,
         activePropertyId: null
       };
+    case 'LOAD_MAP':
+      // this could be undefined for old maps
+      const displayActive = action.payload.data.mapLayers.ownershipDisplay || false;
+      return {
+        ...state,
+        displayActive
+      }
     default:
       return state;
   }


### PR DESCRIPTION
#### What? Why?

Part of #294 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


#### What should we test?
- Save a new map and then toggle the land ownership layer.
- After toggling, the map should autosave (indicated under the map title)
- Refresh the browser, re-open the map and the layer should be displayed according to its previous state

Note that any highlighted properties will be lost. This work is to be completed in the rest of #294 

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
