### PR TITLE
LX-293 Check out version of mapbox-gl-draw with fix for touch screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@gocardless/react-dropin": "^0.3.0",
-    "@mapbox/mapbox-gl-draw": "^1.3.0",
+    "@mapbox/mapbox-gl-draw": "git+https://github.com/mapbox/mapbox-gl-draw.git#84e35b7aa308c69a44b483296baa6ac1c6dc9db8",
     "@mapbox/mapbox-gl-draw-static-mode": "^1.0.1",
     "@mapbox/mapbox-gl-geocoder": "^4.7.4",
     "@turf/turf": "^6.5.0",

--- a/src/components/map/MapboxMap.js
+++ b/src/components/map/MapboxMap.js
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import ReactMapboxGl from "react-mapbox-gl";
 import { v4 as uuidv4 } from "uuid";
 import * as turf from "@turf/turf";
-import MapboxDraw from "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.js";
+import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import DrawControl from "react-mapbox-gl-draw";
 import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
 import StaticMode from "@mapbox/mapbox-gl-draw-static-mode";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,10 +1570,9 @@
   resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-draw-static-mode/-/mapbox-gl-draw-static-mode-1.0.1.tgz#da873099b60acaf91790b961ce84b2c762815041"
   integrity sha512-r/y50dlRJ8ctK5YdhAzimiKIu/R2b0GkGoExw7zWn17CDTn2ftGqsljJOlfLXf5rH15Wv75t1EN9KsM6OkdhWQ==
 
-"@mapbox/mapbox-gl-draw@^1.3.0":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.2.tgz#3ec71d496f056313707c67e62728945563336a85"
-  integrity sha512-Zvl5YN+tIuYZlzPmuzOgkoJsZX6sHMQsnFI+O3ox8EwYkpLO2w0U2FvVhQuVnq1Yys12x6UnF+0IPoEdBy2UfA==
+"@mapbox/mapbox-gl-draw@git+https://github.com/mapbox/mapbox-gl-draw.git#84e35b7aa308c69a44b483296baa6ac1c6dc9db8":
+  version "1.3.0"
+  resolved "git+https://github.com/mapbox/mapbox-gl-draw.git#84e35b7aa308c69a44b483296baa6ac1c6dc9db8"
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/geojson-extent" "^1.0.1"


### PR DESCRIPTION
#### What? Why?

Closes #293
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
Tapping on drawn polygons and the property boundary layer doesn't work on touch screens.

We're hitting the problem described here https://github.com/mapbox/mapbox-gl-draw/pull/869

The issue was fixed by https://github.com/mapbox/mapbox-gl-draw/pull/1146 in this commit https://github.com/mapbox/mapbox-gl-draw/commit/84e35b7aa308c69a44b483296baa6ac1c6dc9db8
However, they reverted the fix because it broke editing of drawings on mobile https://github.com/mapbox/mapbox-gl-draw/pull/1158

But we don't allow drawings on mobile anyway, so this doesn't matter to us.

So we will use this specific commit of the mapbox-gl-draw repo, and we can wait on a proper fix before we upgrade the package again

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- On desktop, save a map with a polygon
- Open this saved map on a mobile device and try to select the polygon by tapping.
- Also, enable the property boundaries layer and try to select a property

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
