### PR TITLE
316 - SFG reload map on refresh

### DIFF
--- a/src/actions/MapActions.js
+++ b/src/actions/MapActions.js
@@ -412,17 +412,11 @@ const shortenTimestamp = (timestamp) => {
 
 export const loadMapFromStorageId = (mapId) => {
   return async (dispatch, getState) => {
-    if (mapId === null) {
-      console.warn("No mapId in sessionStorage");
-      return;
-    }
-
     await dispatch(getMyMaps());
     const map = getState().myMaps.maps.find((item) => item.map.eid === mapId);
 
     if (map) {
       const mapData = JSON.parse(map.map.data);
-      console.log("MapId and data based on sessionStorage", mapId, mapData);
       const isSnapshot = map.map.isSnapshot;
       const lastModified = map.map.lastModified;
       const writeAccess = map.access !== constants.MAP_ACCESS_READ_ONLY;

--- a/src/components/left-pane/LeftPaneLandData.js
+++ b/src/components/left-pane/LeftPaneLandData.js
@@ -149,7 +149,6 @@ const LeftPaneLandData = ({ open, active, onClose }) => {
                 .filter((dataGroup) => dataGroup.userGroupId == userGroup.id)
                 .map(
                   (dataGroup) => (
-                    console.log("From LeftPaneLandData", dataGroup),
                     (
                       <div
                         className={"datagroup-style-wrapper"}

--- a/src/components/map/MapboxMap.js
+++ b/src/components/map/MapboxMap.js
@@ -27,6 +27,7 @@ import {
 import MapRelatedProperties from "./MapRelatedProperties";
 import FeedbackTab from "../common/FeedbackTab";
 import MapBeingEditedToast from "./MapBeingEditedToast";
+import { loadMapFromStorageId } from "../../actions/MapActions";
 
 // Create Map Component with settings
 const Map = ReactMapboxGl({
@@ -70,6 +71,18 @@ const MapboxMap = () => {
   useEffect(() => {
     redrawPolygons(polygons);
   }, [currentMapId, unsavedMapUuid]);
+
+  useEffect(() => {
+    const storedMapId = parseInt(sessionStorage.getItem("currentMapId"));
+    if (storedMapId) {
+      // Dispatch action to load the map from the stored ID
+      dispatch(loadMapFromStorageId(storedMapId));
+      console.log(
+        "currentMapId from sessionStorage",
+        sessionStorage.getItem("currentMapId")
+      );
+    }
+  }, []);
 
   const [styleLoaded, setStyleLoaded] = useState(false);
   const [redrawing, setRedrawing] = useState(false);

--- a/src/components/map/MapboxMap.js
+++ b/src/components/map/MapboxMap.js
@@ -27,7 +27,6 @@ import {
 import MapRelatedProperties from "./MapRelatedProperties";
 import FeedbackTab from "../common/FeedbackTab";
 import MapBeingEditedToast from "./MapBeingEditedToast";
-import { loadMapFromStorageId } from "../../actions/MapActions";
 
 // Create Map Component with settings
 const Map = ReactMapboxGl({
@@ -71,14 +70,6 @@ const MapboxMap = () => {
   useEffect(() => {
     redrawPolygons(polygons);
   }, [currentMapId, unsavedMapUuid]);
-
-  // Load map from session storage if it exists
-  useEffect(() => {
-    const storedMapId = parseInt(sessionStorage.getItem("currentMapId"));
-    if (storedMapId) {
-      dispatch(loadMapFromStorageId(storedMapId));
-    }
-  }, []);
 
   const [styleLoaded, setStyleLoaded] = useState(false);
   const [redrawing, setRedrawing] = useState(false);

--- a/src/components/map/MapboxMap.js
+++ b/src/components/map/MapboxMap.js
@@ -72,15 +72,11 @@ const MapboxMap = () => {
     redrawPolygons(polygons);
   }, [currentMapId, unsavedMapUuid]);
 
+  // Load map from session storage if it exists
   useEffect(() => {
     const storedMapId = parseInt(sessionStorage.getItem("currentMapId"));
     if (storedMapId) {
-      // Dispatch action to load the map from the stored ID
       dispatch(loadMapFromStorageId(storedMapId));
-      console.log(
-        "currentMapId from sessionStorage",
-        sessionStorage.getItem("currentMapId")
-      );
     }
   }, []);
 


### PR DESCRIPTION
#### What? Why?

Closes #316

If a browser refresh is performed when a map is open, LX is reloaded with the default untitled map.

As suggested by @rogup, on opening a map the mapId is added to the browser's sessionStorage, and when browser tab is reloaded a check is run and if a mapId is present the requisite map is reloaded.

#### What should we test?
- Log in to LX
- open a map
- use map
- refresh the browser tab