### PR TITLE
Ownership Search - highlighting fix for selected properties

### DIFF
--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -21,7 +21,7 @@ const RelatedProperties = ({ property }) => {
 
   const gotoProperty = () => {
     dispatch(setLngLat(lng, lat));
-    handlePropertyClick();
+    dispatch(selectRelatedProperties({ [property.poly_id]: property }));
   }
 
   return (

--- a/src/components/left-pane/RelatedProperties.js
+++ b/src/components/left-pane/RelatedProperties.js
@@ -21,39 +21,45 @@ const RelatedProperties = ({ property }) => {
 
   const gotoProperty = () => {
     dispatch(setLngLat(lng, lat));
+    handlePropertyClick();
   }
 
-  return <div
-    className={`search-result ${active && "active"}`}
-    key={property.title_no}
-  >
-    <i onClick={handlePropertyClick}>
-      <svg
-        className="icon-property"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 12.6 18"
+  return (
+    <div
+      className={`search-result ${active ? "active" : ""}`}
+      key={property.title_no}
+    >
+      <i onClick={handlePropertyClick}>
+        <svg
+          className="icon-property"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 12.6 18"
+        >
+          <path
+            d="M13.8,3A6.3,6.3,0,0,0,7.5,9.3c0,4.725,6.3,11.7,6.3,11.7s6.3-6.975,6.3-11.7A6.3,6.3,0,0,0,13.8,3Zm0,8.55A2.25,2.25,0,1,1,16.05,9.3,2.251,2.251,0,0,1,13.8,11.55Z"
+            transform="translate(-7.5 -3)"
+          />
+        </svg>
+      </i>
+      <div
+        className="search-result__property"
+        onClick={handlePropertyClick}
       >
-        <path
-          d="M13.8,3A6.3,6.3,0,0,0,7.5,9.3c0,4.725,6.3,11.7,6.3,11.7s6.3-6.975,6.3-11.7A6.3,6.3,0,0,0,13.8,3Zm0,8.55A2.25,2.25,0,1,1,16.05,9.3,2.251,2.251,0,0,1,13.8,11.55Z"
-          transform="translate(-7.5 -3)"
-        />
-      </svg>
-    </i>
-    <div className="search-result__property" onClick={handlePropertyClick}>
-      <h4 className="search-result__property-address">
-        {property.property_address}
-      </h4>
-      <div className="search-result__title-no">
-        Title no: {property.title_no}
+        <h4 className="search-result__property-address">
+          {property.property_address}
+        </h4>
+        <div className="search-result__title-no">
+          Title no: {property.title_no}
+        </div>
       </div>
+      <button
+        alt="move map to property icon"
+        title="Go to Property"
+        className="search-result__goto-icon"
+        onClick={gotoProperty}
+      />
     </div>
-    <button
-      alt="move map to property icon"
-      title="Go to Property"
-      className="search-result__goto-icon"
-      onClick={gotoProperty}
-    />
-  </div>
+  );
 
 };
 


### PR DESCRIPTION
#### What? Why?

Currently, when an arrow next to a property within the 'Ownership Search' panel is clicked, the property is not highlighted in red on the map.

Closes #311

After investigation the `handlePropertyClick` function only needed to be be added to the `gotoProperty` function within `RelatedProperties.js`.

I was unable to reproduce the second bug mentioned in issue #311 locally, on staging or on live (click 'clear all' within the 'Ownership Search' panel, click another property within this panel and all properties listed in the panel are highlighted green).

#### What should we test?

1. Turn on ownership search
2. Zoom in and click on a green poly
3. Open the 'Land Information' panel and click 'Check for other properties'
4. Click an arrow to the right of a property within the 'Ownership Search' panel