### PR TITLE
Query properties after zoom has ended

### DIFF
--- a/src/actions/MapActions.js
+++ b/src/actions/MapActions.js
@@ -351,6 +351,12 @@ export const setZoom = (zoom) => {
   };
 };
 
+export const setZooming = (zooming) => {
+  return (dispatch) => {
+    dispatch({ type: "SET_ZOOMING", payload: zooming });
+  };
+};
+
 export const setSearchMarker = (lng, lat) => {
   return (dispatch) => {
     dispatch({

--- a/src/components/map-controls/ControlButtons.js
+++ b/src/components/map-controls/ControlButtons.js
@@ -9,8 +9,10 @@ import MenuKey from './MenuKey';
 const ControlButtons = () => {
     const [menuLayersOpen, setMenuLayersOpen] = useState(false);
     const [menuKeyOpen, setMenuKeyOpen] = useState(false);
-    const [zooming, setZooming] = useState(false);
-    const landDataLayers = useSelector((state) => state.mapLayers.landDataLayers);
+    const { zooming } = useSelector((state) => state.map);
+    const landDataLayers = useSelector(
+      (state) => state.mapLayers.landDataLayers
+    );
     const propertiesDisplayed = useSelector(
       (state) =>
         state.landOwnership.displayActive ||
@@ -19,72 +21,87 @@ const ControlButtons = () => {
     const dispatch = useDispatch();
 
     const getLocation = () => {
-        if (navigator.geolocation) {
-            dispatch(openModal('location'));
-            navigator.geolocation.getCurrentPosition((position) => {
-                console.log("geolocation position", position);
-                let lat = position.coords.latitude;
-                let lng = position.coords.longitude;
-                dispatch(closeModal('location'));
-                dispatch(setZoom([17]));
-                dispatch(setLngLat(lng, lat));
-                dispatch(setCurrentLocation(lng, lat));
-            }, (error) => {
-                console.log("There was an error", error);
-                dispatch(closeModal('location'));
-            });
-        }
-    }
+      if (navigator.geolocation) {
+        dispatch(openModal("location"));
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            console.log("geolocation position", position);
+            let lat = position.coords.latitude;
+            let lng = position.coords.longitude;
+            dispatch(closeModal("location"));
+            dispatch(setZoom([17]));
+            dispatch(setLngLat(lng, lat));
+            dispatch(setCurrentLocation(lng, lat));
+          },
+          (error) => {
+            console.log("There was an error", error);
+            dispatch(closeModal("location"));
+          }
+        );
+      }
+    };
 
-    return <div>
-        <MenuLayers open={menuLayersOpen} setOpen={(open) => {
+    return (
+      <div>
+        <MenuLayers
+          open={menuLayersOpen}
+          setOpen={(open) => {
             setMenuLayersOpen(open);
-            open && setMenuKeyOpen(false)
-        }} />
+            open && setMenuKeyOpen(false);
+          }}
+        />
         {
-            // If layers are active show button toggle key menu
-            landDataLayers.length && <MenuKey open={menuKeyOpen} setOpen={(open) => {
+          // If layers are active show button toggle key menu
+          landDataLayers.length && (
+            <MenuKey
+              open={menuKeyOpen}
+              setOpen={(open) => {
                 setMenuKeyOpen(open);
-                open && setMenuLayersOpen(false)
-            }} />
+                open && setMenuLayersOpen(false);
+              }}
+            />
+          )
         }
         <div id="controls">
-            <div className="zoom-button zoom-location"
-                onClick={() => getLocation()}
-            />
-            <div className="controls-slider">
-                {propertiesDisplayed &&
-                    <div className="zoom-button zoom-properties"
-                        style={{ marginBottom: '24px' }}
-                        onClick={() => {
-                            if (!zooming) {
-                                dispatch(setZoom([constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL]));
-                            }
-                        }}
-                    />
+          <div
+            className="zoom-button zoom-location"
+            onClick={() => getLocation()}
+          />
+          <div className="controls-slider">
+            {propertiesDisplayed && (
+              <div
+                className="zoom-button zoom-properties"
+                style={{ marginBottom: "24px" }}
+                onClick={() => {
+                  if (!zooming) {
+                    dispatch(
+                      setZoom([constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL])
+                    );
+                  }
+                }}
+              />
+            )}
+            <div
+              className="zoom-button zoom-plus"
+              style={{ marginBottom: "24px" }}
+              onClick={() => {
+                if (!zooming) {
+                  dispatch(zoomIn());
                 }
-                <div className="zoom-button zoom-plus"
-                    style={{ marginBottom: '24px' }}
-                    onClick={() => {
-                        if (!zooming) {
-                            setZooming(true);
-                            dispatch(zoomIn());
-                            setTimeout(() => setZooming(false), 600);
-                        }
-                    }}
-                />
-                <div className="zoom-button zoom-minus"
-                    onClick={() => {
-                        if (!zooming) {
-                            setZooming(true);
-                            dispatch(zoomOut());
-                            setTimeout(() => setZooming(false), 600);
-                        }
-                    }}
-                />
-            </div>
+              }}
+            />
+            <div
+              className="zoom-button zoom-minus"
+              onClick={() => {
+                if (!zooming) {
+                  dispatch(zoomOut());
+                }
+              }}
+            />
+          </div>
         </div>
-    </div>;
+      </div>
+    );
 }
 
 export default ControlButtons;

--- a/src/components/map/MapPendingProperties.js
+++ b/src/components/map/MapPendingProperties.js
@@ -18,7 +18,7 @@ const MapPendingProperties = ({ center, map }) => {
   const displayActive = useSelector(
     (state) => state.landOwnership.pendingDisplayActive
   );
-  const zoom = useSelector((state) => state.map.zoom);
+  const { zoom, zooming } = useSelector((state) => state.map);
   const highlightedProperties = useSelector(
     (state) => state.landOwnership.highlightedProperties
   );
@@ -68,9 +68,13 @@ const MapPendingProperties = ({ center, map }) => {
   };
 
   useEffect(() => {
-    if (displayActive && zoom >= constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL)
+    if (
+      !zooming &&
+      displayActive &&
+      zoom >= constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL
+    )
       getProperties();
-  }, [center, zoom, displayActive]);
+  }, [center, zooming, displayActive]);
 
   const onClickNewProperty = (property) => {
     if (activePanel !== "Drawing Tools") {

--- a/src/components/map/MapProperties.js
+++ b/src/components/map/MapProperties.js
@@ -15,7 +15,7 @@ const MapProperties = ({ center, map }) => {
   const [loadingProperties, setLoadingProperties] = useState(false);
 
   const displayActive = useSelector((state) => state.landOwnership.displayActive);
-  const zoom = useSelector((state) => state.map.zoom);
+  const { zoom, zooming } = useSelector((state) => state.map);
   const highlightedProperties = useSelector((state) => state.landOwnership.highlightedProperties);
   const activePropertyId = useSelector((state) => state.landOwnership.activePropertyId);
   const activeProperty = highlightedProperties[activePropertyId] || null;
@@ -59,9 +59,13 @@ const MapProperties = ({ center, map }) => {
   };
 
   useEffect(() => {
-    if (displayActive && zoom >= constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL)
+    if (
+      !zooming &&
+      displayActive &&
+      zoom >= constants.PROPERTY_BOUNDARIES_ZOOM_LEVEL
+    )
       getProperties();
-  }, [center, zoom, displayActive]);
+  }, [center, zooming, displayActive]);
 
   const onClickNewProperty = (property) => {
     if (activePanel !== "Drawing Tools") {

--- a/src/components/map/MapboxMap.js
+++ b/src/components/map/MapboxMap.js
@@ -24,6 +24,7 @@ import {
   refreshCurrentMap,
   setLngLat,
   setZoom,
+  setZooming,
 } from "../../actions/MapActions";
 import MapRelatedProperties from "./MapRelatedProperties";
 import FeedbackTab from "../common/FeedbackTab";
@@ -279,7 +280,11 @@ const MapboxMap = () => {
               : "#72b6e6",
         }}
         zoom={zoom}
-        onZoomEnd={(map) => dispatch(setZoom([map.getZoom()]))}
+        onZoomStart={() => dispatch(setZooming(true))}
+        onZoomEnd={(map) => {
+          dispatch(setZoom([map.getZoom()]));
+          dispatch(setZooming(false));
+        }}
         onDragEnd={(map) =>
           dispatch(setLngLat(map.getCenter().lng, map.getCenter().lat))
         }

--- a/src/reducers/MapReducer.js
+++ b/src/reducers/MapReducer.js
@@ -1,5 +1,6 @@
 const INITIAL_STATE = {
   zoom: [6],
+  zooming: false,
   lngLat: [-1.5, 53],
   searchMarker: null,
   currentLocation: null,
@@ -35,6 +36,11 @@ export default (state = INITIAL_STATE, action) => {
       return {
         ...state,
         zoom: action.payload,
+      };
+    case "SET_ZOOMING":
+      return {
+        ...state,
+        zooming: action.payload,
       };
     case "SET_LNG_LAT":
       return {


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/DigitalCommons/property-boundaries-service/issues/16

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

If a user enables the property boundaries layer from the initial zoomed out map, then clicks the 'zoom to properties' button, the API request gets fired before zooming in. This means it queries ALL the property data, causing an OOME. I managed to reliably repro this and see the heap size start increasing exactly when I did the above. I also took a node memory snapshot using https://nodejs.org/api/cli.html#--heapsnapshot-near-heap-limitmax_count, and saw over 100K properties in a huge array in the memory, confirming the above.

I'm not sure why this hasn't been an issue before tbh. The only thing I can think of right now is that since I updated some of the npm dependencies recently, maybe there has been an upstream change to one of the SQL libraries causing the command to fail less gracefully.
But anyway, here's a fix for the front-end, so that we don't query so many properties.

I've also added this fix to limit the results on the PBS MySql query as a failsafe: https://github.com/DigitalCommons/property-boundaries-service/commit/f91ddf9d8f8553366d7729e22850c6eb0a8ca01c

I've re-enabled the Uptime Kuma check since this wasn't the issue, but updated the request timeout to 10s. It was previously 48s which was giving some false positive 'server back up' notifications (when MySql was overloaded and the heap was almost at maximum, the odd request was maybe getting through successfully)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit LX
- Enable property boundaries layer and click the button to zoom in
- The loading animation should only appear after zoom ends

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->
This could maybe be applied as a hotfix to the LX prod front-end, so that the PBS can be restarted on prod-2

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
