### PR TITLE
add markers to data group polygons where the data group requests them

### DIFF
--- a/src/components/map/Markers.js
+++ b/src/components/map/Markers.js
@@ -125,8 +125,8 @@ const Markers = ({ map, popupVisible, setPopupVisible }) => {
                 description={polygon.description}
                 marker={polygon}
                 access={dataGroup.access}
-                popupVisible={false}
-                setPopupVisible={setPopupVisible}
+                popupVisible={false} // we don't want this additional marker to show a popup of its own
+                setPopupVisible={setPopupVisible} // setPopupVisible will use the UUID of the polygon, toggling the polygon's own popup
               />
             );
           });


### PR DESCRIPTION

#### What? Why?

Resolves #345

Add extra markers with no popup to the data group polygons where the datagroup has show_marker_in_polys as true


#### What should we test?

- Open a datagroup that has the show_marker_in_polys flag marked as true (or 1 in the db instead of 0)
- Note the markers

#### Release notes




#### Deployment notes

No
