### PR TITLE
357 sfgbug toggle colours on data groups reverted to default

### DIFF
--- a/src/components/left-pane/LeftPaneLandData.js
+++ b/src/components/left-pane/LeftPaneLandData.js
@@ -169,7 +169,7 @@ const LeftPaneLandData = ({ open, active, onClose }) => {
                 .map((dataGroup) => (
                   <div
                     className={"datagroup-style-wrapper"}
-                    style={{ "--data-group-colour": dataGroup.hex_colour, "border": "1px solid #fff" }}
+                    style={{ "--data-group-colour": dataGroup.hex_colour }}
                     key={dataGroup.id}
                   >
                     <LeftPaneToggle


### PR DESCRIPTION
#### What? Why?

Relates to #357

The button toggle colour for SFG data groups no longer worked.

Made a minor update to `src/components/left-pane/LeftPaneLandData.js` changing the property name from `hex_color` to `hex_colour`.


#### What should we test?
- Open the layers panel
- Scroll down to the **Resilient Green Spaces** data groups
- Toggle each data group, checking that the correct data group colour is shown
