### PR TITLE
370 lx im getting spammed by feedback requests every few seconds even after checking dont show this again

### DIFF
--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -8,3 +8,21 @@ export const getUserDetails = () => {
         }
     }
 }
+
+
+export const getAskForFeedback = () => {
+  return async (dispatch) => {
+    const askForFeedback = await dispatch(
+      getRequest("/api/user/ask-for-feedback")
+    );
+    console.log("API response for askForFeedback:", askForFeedback);
+    if (askForFeedback) {
+      dispatch({ type: "SET_ASK_FOR_FEEDBACK", payload: askForFeedback });
+      console.log(
+        "Dispatched SET_ASK_FOR_FEEDBACK with payload:",
+        askForFeedback
+      );
+    }
+  };
+};
+

--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -1,28 +1,38 @@
-import { getRequest } from './RequestActions';
+import { getRequest, postRequest } from "./RequestActions";
 
 export const getUserDetails = () => {
-    return async dispatch => {
-        const userData = await dispatch(getRequest('/api/user/details'));
-        if (userData) {
-            dispatch({ type: 'POPULATE_USER', payload: userData });
-        }
-    }
-}
-
-
-export const getAskForFeedback = () => {
   return async (dispatch) => {
-    const askForFeedback = await dispatch(
-      getRequest("/api/user/ask-for-feedback")
-    );
-    console.log("API response for askForFeedback:", askForFeedback);
-    if (askForFeedback) {
-      dispatch({ type: "SET_ASK_FOR_FEEDBACK", payload: askForFeedback });
-      console.log(
-        "Dispatched SET_ASK_FOR_FEEDBACK with payload:",
-        askForFeedback
-      );
+    const userData = await dispatch(getRequest("/api/user/details"));
+    if (userData) {
+      dispatch({ type: "POPULATE_USER", payload: userData });
     }
   };
 };
 
+export const getAskForFeedback = () => {
+  return async (dispatch) => {
+    const response = await dispatch(getRequest("/api/user/ask-for-feedback"));
+    // Always extract the boolean not the object
+    if (response && typeof response.askForFeedback === "boolean") {
+      dispatch({
+        type: "USER_FEEDBACK_STATUS",
+        payload: response.askForFeedback,
+      });
+    }
+  };
+};
+
+export const setAskForFeedback = (status) => {
+  return async (dispatch) => {
+    const success = await dispatch(
+      postRequest("/api/user/ask-for-feedback", { askForFeedback: status })
+    );
+
+    if (success) {
+      dispatch({
+        type: "USER_FEEDBACK_STATUS",
+        payload: status,
+      });
+    }
+  };
+};

--- a/src/components/modals/FeedbackPopUp.js
+++ b/src/components/modals/FeedbackPopUp.js
@@ -10,10 +10,7 @@ const FeedbackPopUp = () => {
   const propertyLayerActive = useSelector(
     (state) => state.landOwnership.activeDisplay
   );
-
   const feedbackPreference = useSelector((state) => state.user.askForFeedback);
-
-  console.log("Feedback preference from state:", feedbackPreference);
 
   const closeModal = () => {
     dispatch({
@@ -29,7 +26,7 @@ const FeedbackPopUp = () => {
 
   const handleCheckboxChange = (e) => {
     if (e.target.checked) {
-      dispatch(setAskForFeedback(false)); // This should update the server and redux
+      dispatch(setAskForFeedback(false));
     } else {
       dispatch(setAskForFeedback(true));
     }
@@ -50,40 +47,21 @@ const FeedbackPopUp = () => {
     return () => {
       document.removeEventListener("mouseleave", handleMouseLeave);
     };
-  }, [feedbackPreference, dispatch]);
-
-  // const dontAskForFeedback = () => {
-  //   const feedbackModalPreference = localStorage.getItem("feedbackPreference");
-  //   return feedbackModalPreference === "false";
-  // };
-
-  // Show modal after delay if property layer is active
-  // useEffect(() => {
-  //   if (propertyLayerActive) {
-  //     setAskForFeedback(true);
-  //     setTimeout(() => {
-  //       dispatch(openModal("feedbackPopUp"));
-  //     }, 300000);
-
-  //     return () => {
-  //       clearTimeout();
-  //     };
-  //   }
-  //   console.log("propertyLayerActive", propertyLayerActive);
-  // }, [propertyLayerActive]);
+  }, [feedbackPreference]);
 
   // Show modal after delay if property layer is active
   useEffect(() => {
     let timeoutId;
     if (propertyLayerActive && feedbackPreference) {
+      clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
         dispatch(openModal("feedbackPopUp"));
       }, 300000);
     }
     return () => {
-      if (timeoutId) clearTimeout(timeoutId);
+      clearTimeout(timeoutId);
     };
-  }, [propertyLayerActive, feedbackPreference, dispatch]);
+  }, [propertyLayerActive]);
 
   return (
     <Modal

--- a/src/pages/MapApp.js
+++ b/src/pages/MapApp.js
@@ -8,7 +8,7 @@ import ControlButtons from '../components/map-controls/ControlButtons';
 import Spinner from '../components/common/Spinner';
 import * as Auth from "../utils/Auth";
 import { getMyMaps, openMap } from '../actions/MapActions';
-import { getUserDetails } from '../actions/UserActions';
+import { getUserDetails, getAskForFeedback } from '../actions/UserActions';
 import NoConnectionToast from '../components/map/NoConnectionToast';
 import {
   establishSocketConnection,
@@ -29,6 +29,7 @@ const MapApp = () => {
      // If authenticated, get user details, setup websocket connection, and get maps
      await dispatch(getUserDetails());
      dispatch(establishSocketConnection());
+     dispatch(getAskForFeedback());
      await dispatch(getMyMaps());
 
      // Open the map that was previously open if the page was refreshed

--- a/src/reducers/UserReducer.js
+++ b/src/reducers/UserReducer.js
@@ -34,7 +34,7 @@ export default (state = INITIAL_STATE, action) => {
           action.payload.firstName[0].toUpperCase() +
           action.payload.lastName[0].toUpperCase(),
       };
-    case "SET_ASK_FOR_FEEDBACK":
+    case "USER_FEEDBACK_STATUS":
       return {
         ...state,
         askForFeedback: action.payload,

--- a/src/reducers/UserReducer.js
+++ b/src/reducers/UserReducer.js
@@ -19,6 +19,7 @@ const INITIAL_STATE = {
   username: "",
   populated: false,
   privileged: false,
+  askForFeedback: true,
 };
 
 export default (state = INITIAL_STATE, action) => {
@@ -32,6 +33,11 @@ export default (state = INITIAL_STATE, action) => {
         initials:
           action.payload.firstName[0].toUpperCase() +
           action.payload.lastName[0].toUpperCase(),
+      };
+    case "SET_ASK_FOR_FEEDBACK":
+      return {
+        ...state,
+        askForFeedback: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
### What? Why?
The previous feedback pop-up implementation was buggy with users being increasingly spammed by the pop-up. This iteration takes the back-end updates introduced [here](https://github.com/DigitalCommons/land-explorer-back-end/pull/69), that added an `ask_for_feedback` column to the `user` table, and updates / sets the redux state based on the db value, instead of local storage.

Relates to #370 <!-- Insert issue number here. -->
In conjunction with PR [#69](https://github.com/DigitalCommons/land-explorer-back-end/pull/69)

#### New functionality for managing feedback preferences:
* [`src/actions/UserActions.js`](diffhunk://#diff-0947d6ee4a669d435cf3e4ecee5bd5619232c4a139096606210837c3f1c37889L1-R38): Added `getAskForFeedback` and `setAskForFeedback` actions to fetch and update the user's feedback preference using API endpoints.

#### Updates to the `FeedbackPopUp` component:
* [`src/components/modals/FeedbackPopUp.js`](diffhunk://#diff-3ec2af614d62057e76f3cc83cf80a95cae8aff17eb44bb7015f2a7a19586d70cR6-L15): Replaced local storage usage with Redux state for managing the feedback preference (`askForFeedback`). The component now dispatches `setAskForFeedback` to update the preference and uses the Redux selector `state.user.askForFeedback` to determine the current status. [[1]](diffhunk://#diff-3ec2af614d62057e76f3cc83cf80a95cae8aff17eb44bb7015f2a7a19586d70cR6-L15) [[2]](diffhunk://#diff-3ec2af614d62057e76f3cc83cf80a95cae8aff17eb44bb7015f2a7a19586d70cL28-R38) [[3]](diffhunk://#diff-3ec2af614d62057e76f3cc83cf80a95cae8aff17eb44bb7015f2a7a19586d70cL49-L68) [[4]](diffhunk://#diff-3ec2af614d62057e76f3cc83cf80a95cae8aff17eb44bb7015f2a7a19586d70cL96-R91)

#### Integration with the application lifecycle:
* [`src/pages/MapApp.js`](diffhunk://#diff-ce45bb72adbba36f8726db35dd5e76a87774162e3dcb090f1f588bb4943d9061L11-R11): Added a call to `getAskForFeedback` during the app initialization process to ensure the feedback preference is loaded when the user logs in. [[1]](diffhunk://#diff-ce45bb72adbba36f8726db35dd5e76a87774162e3dcb090f1f588bb4943d9061L11-R11) [[2]](diffhunk://#diff-ce45bb72adbba36f8726db35dd5e76a87774162e3dcb090f1f588bb4943d9061R32)

#### State management updates:
* [`src/reducers/UserReducer.js`](diffhunk://#diff-8cd9aae5b0eca01b2fd28c2fecbc26aaea8ece0314e2395769aec14d94caa416R22): Updated the initial state to include `askForFeedback` (defaulting to `true`) and added a new case in the reducer to handle the `USER_FEEDBACK_STATUS` action for updating the state. [[1]](diffhunk://#diff-8cd9aae5b0eca01b2fd28c2fecbc26aaea8ece0314e2395769aec14d94caa416R22) [[2]](diffhunk://#diff-8cd9aae5b0eca01b2fd28c2fecbc26aaea8ece0314e2395769aec14d94caa416R37-R41)


### Release notes

Requires the merging of PR [#69](https://github.com/DigitalCommons/land-explorer-back-end/pull/69) and a `user` table update before testing is possible

### What should we test?
- Toggle on a Land Ownership layer and ensure it takes 5 mins for the pop-up to appear
- Move you mouse up the address bar to activate the pop-up
- Click the 'Don't show this again' checkbox
- Close the pop-up
- Move you mouse up the address bar and ensure the pop-up does not appear
- Repeat step 1 ensuring no pop-up appears