### PR TITLE
Update FeedbackPopUp > added useRef

### DIFF
--- a/src/components/modals/FeedbackPopUp.js
+++ b/src/components/modals/FeedbackPopUp.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Modal from "./Modal";
 import { openModal } from "../../actions/ModalActions";
@@ -11,6 +11,8 @@ const FeedbackPopUp = () => {
     (state) => state.landOwnership.activeDisplay
   );
   const feedbackPreference = useSelector((state) => state.user.askForFeedback);
+
+  const timeoutRef = useRef();
 
   const closeModal = () => {
     dispatch({
@@ -51,17 +53,21 @@ const FeedbackPopUp = () => {
 
   // Show modal after delay if property layer is active
   useEffect(() => {
-    let timeoutId;
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
     if (propertyLayerActive && feedbackPreference) {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         dispatch(openModal("feedbackPopUp"));
       }, 300000);
     }
     return () => {
-      clearTimeout(timeoutId);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
     };
-  }, [propertyLayerActive]);
+  }, [propertyLayerActive, feedbackPreference]);
 
   return (
     <Modal


### PR DESCRIPTION
#### What? Why?

This PR refactors the feedback modal logic in `FeedbackPopUp.js` to prevent multiple timer issues, switching from a local variable to a `useRef` hook for storing the timeout ID, which ensures proper cleanup and avoids memory leaks.

Relates to #370  <!-- Insert issue number here. -->

**Feedback modal timer management improvements:**

* Replaced the local `timeoutId` variable with a `useRef` hook (`timeoutRef`) to persist the timeout ID across renders and reliably clear the timer when needed. [[1]](diffhunk://#diff-3ec2af614d62057e76f3cc83cf80a95cae8aff17eb44bb7015f2a7a19586d70cL1-R1) [[2]](diffhunk://#diff-3ec2af614d62057e76f3cc83cf80a95cae8aff17eb44bb7015f2a7a19586d70cR15-R16)
* Updated the `useEffect` dependency array to include `feedbackPreference`, ensuring the modal logic responds to changes in both `propertyLayerActive` and the user's feedback preference.
* Improved timer cleanup in the `useEffect` return function by checking and clearing the timeout stored in `timeoutRef`, preventing multiple timers and potential memory leaks.

#### What should we test?
- Click the Data Layers icon on the left nav bar
- Toggle between the Land Ownership layers
- Ensure that one Land Ownership layer is left on
- Wait 5 minutes for the feed back pop-up to fire
- Ensure that no other pop-ups appear
- Repeat the first two steps of this process
- Ensure all Land Ownership layer are switched off
- Wait 5 minutes and ensure no feed back pop-ups fire
