### PR TITLE
ControlButton.js - reintroduced zooming variable

### DIFF
--- a/src/components/map-controls/ControlButtons.js
+++ b/src/components/map-controls/ControlButtons.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import {
   setLngLat,
   zoomIn,
@@ -11,6 +11,7 @@ import { openModal, closeModal } from "../../actions/ModalActions";
 
 const ControlButtons = () => {
   const dispatch = useDispatch();
+  const { zooming } = useSelector((state) => state.map);
 
   const getLocation = () => {
     if (navigator.geolocation) {


### PR DESCRIPTION
#### What? Why?

Map zoom buttons were no longer working in staging.

Relates to #373

The  `zooming` variable was missing from `ControlButtons.js`, so re-introduced `const { zooming } = useSelector((state) => state.map);` to the component.


#### What should we test?
- Visit Land Explorer
- Zoom in and out using the zoom buttons

