### PR TITLE
365 lx new property display ux bugs

### DIFF
--- a/src/assets/styles/_properties.scss
+++ b/src/assets/styles/_properties.scss
@@ -21,6 +21,7 @@
 
 .property-section-header__title-no {
   color: $secondaryColor;
+  user-select: text;
 }
 
 .property-section-header__remove {

--- a/src/components/left-pane/RelatedProperty.js
+++ b/src/components/left-pane/RelatedProperty.js
@@ -4,7 +4,6 @@ import * as turf from "@turf/turf";
 import {
   clearHighlightedProperties,
   highlightProperties,
-  setActiveProperty,
 } from "../../actions/LandOwnershipActions";
 import { setLngLat, setZoom } from "../../actions/MapActions";
 
@@ -30,7 +29,6 @@ const RelatedProperty = ({ property }) => {
     dispatch(setLngLat(lng, lat));
     dispatch(setZoom([17]));
     dispatch(highlightProperties({ [property.poly_id]: property }));
-    dispatch(setActiveProperty(property.poly_id));
   };
 
   return (

--- a/src/components/left-pane/property-section/PropertySection.js
+++ b/src/components/left-pane/property-section/PropertySection.js
@@ -39,7 +39,7 @@ const PropertySection = ({ property, active }) => {
 
   // calculate area and perimeter
   const area = Math.round(turf.area(geom));
-  const perimeter = Math.round(turf.length(geom, {units: "meters"}));
+  const perimeter = Math.round(turf.length(geom, { units: "meters" }));
 
   const proprietors = [
     {
@@ -78,6 +78,7 @@ const PropertySection = ({ property, active }) => {
   };
 
   const open = poly_id === activePropertyId;
+  const freehold = tenure?.toLowerCase() === "freehold";
 
   return (
     <div className="left-pane-tray-section">
@@ -108,6 +109,7 @@ const PropertySection = ({ property, active }) => {
             perimeter={perimeter}
             polyId={poly_id}
             unregistered={tenure === "unregistered"}
+            freehold={freehold}
           />
           {proprietor_category_1 && (
             <>
@@ -120,7 +122,10 @@ const PropertySection = ({ property, active }) => {
             </>
           )}
 
-          <PropertySectionSmallPrint tenure={tenure} unregistered={tenure === "unregistered"} />
+          <PropertySectionSmallPrint
+            freehold={freehold}
+            unregistered={tenure === "unregistered"}
+          />
         </div>
       )}
     </div>

--- a/src/components/left-pane/property-section/PropertySection.js
+++ b/src/components/left-pane/property-section/PropertySection.js
@@ -120,7 +120,7 @@ const PropertySection = ({ property, active }) => {
             </>
           )}
 
-          <PropertySectionSmallPrint unregistered={tenure === "unregistered"} />
+          <PropertySectionSmallPrint tenure={tenure} unregistered={tenure === "unregistered"} />
         </div>
       )}
     </div>

--- a/src/components/left-pane/property-section/overview-details/OverviewDetails.js
+++ b/src/components/left-pane/property-section/overview-details/OverviewDetails.js
@@ -6,6 +6,7 @@ const OverviewDetails = ({
   perimeter,
   polyId,
   unregistered,
+  freehold
 }) => {
   return (
     <section>
@@ -33,7 +34,7 @@ const OverviewDetails = ({
           </div>
           {!unregistered && (
             <div className="property-details-info__inner">
-              <div className="property-details-info__title">Poly ID:</div>
+              <div className="property-details-info__title">{freehold ? "INSPIRE" : "HMLR Poly"} ID:</div>
               <div className="property-details-info__value">{polyId}</div>
             </div>
           )}

--- a/src/components/left-pane/property-section/overview-details/OverviewDetails.js
+++ b/src/components/left-pane/property-section/overview-details/OverviewDetails.js
@@ -8,6 +8,8 @@ const OverviewDetails = ({
   unregistered,
   freehold
 }) => {
+  const isLongAddress = address && address.length > 70;
+
   return (
     <section>
       <div className="property-inner-section">
@@ -15,7 +17,7 @@ const OverviewDetails = ({
           <i className="property-inner-section__icon overview-icon"></i>
           <span>Overview</span>
         </h3>
-        {address && (
+        {isLongAddress && (
           <div className="property-details-info">
             <div className="property-details-info__title">Full Address:</div>
             <div className="property-details-info__value">{address}</div>
@@ -34,7 +36,9 @@ const OverviewDetails = ({
           </div>
           {!unregistered && (
             <div className="property-details-info__inner">
-              <div className="property-details-info__title">{freehold ? "INSPIRE" : "HMLR Poly"} ID:</div>
+              <div className="property-details-info__title">
+                {freehold ? "INSPIRE" : "HMLR Poly"} ID:
+              </div>
               <div className="property-details-info__value">{polyId}</div>
             </div>
           )}

--- a/src/components/left-pane/property-section/ownership-details/OwnershipDetails.js
+++ b/src/components/left-pane/property-section/ownership-details/OwnershipDetails.js
@@ -25,16 +25,16 @@ const OwnershipDetails = ({ tenure, dateAdded, proprietors }) => {
             <div className="property-details-info__value">{tenure}</div>
           </div>
           <div className="property-details-info__inner">
-            <div className="property-details-info__title">Last Change:</div>
-            <div className="property-details-info__value">{dateAdded}</div>
-          </div>
-          <div className="property-details-info__inner">
             <div className="property-details-info__title">
               Proprietor{proprietorCount > 1 && " One"}
             </div>
             <div className="property-details-info__value">
               {proprietorOne.name}
             </div>
+          </div>
+          <div className="property-details-info__inner">
+            <div className="property-details-info__title">Last Change:</div>
+            <div className="property-details-info__value">{dateAdded}</div>
           </div>
         </div>
       </div>

--- a/src/components/left-pane/property-section/ownership-details/OwnershipDetails.js
+++ b/src/components/left-pane/property-section/ownership-details/OwnershipDetails.js
@@ -4,6 +4,7 @@ import ProprietorCard from "./proprietor-card/ProprietorCard";
 const OwnershipDetails = ({ tenure, dateAdded, proprietors }) => {
   const [showMore, setShowMore] = useState(false);
   const proprietorCount = proprietors.length;
+  const proprietorOne = proprietors[0];
 
   return (
     <section>
@@ -26,6 +27,14 @@ const OwnershipDetails = ({ tenure, dateAdded, proprietors }) => {
           <div className="property-details-info__inner">
             <div className="property-details-info__title">Last Change:</div>
             <div className="property-details-info__value">{dateAdded}</div>
+          </div>
+          <div className="property-details-info__inner">
+            <div className="property-details-info__title">
+              Proprietor{proprietorCount > 1 && " One"}
+            </div>
+            <div className="property-details-info__value">
+              {proprietorOne.name}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/left-pane/property-section/ownership-details/OwnershipDetails.js
+++ b/src/components/left-pane/property-section/ownership-details/OwnershipDetails.js
@@ -24,9 +24,7 @@ const OwnershipDetails = ({ tenure, dateAdded, proprietors }) => {
             <div className="property-details-info__value">{tenure}</div>
           </div>
           <div className="property-details-info__inner">
-            <div className="property-details-info__title">
-              Date Proprietor Added:
-            </div>
+            <div className="property-details-info__title">Last Change:</div>
             <div className="property-details-info__value">{dateAdded}</div>
           </div>
         </div>

--- a/src/components/left-pane/property-section/property-section-small-print/PropertySectionSmallPrint.js
+++ b/src/components/left-pane/property-section/property-section-small-print/PropertySectionSmallPrint.js
@@ -1,6 +1,12 @@
 import React from "react";
 
-const PropertySectionSmallPrint = ({ unregistered }) => {
+const PropertySectionSmallPrint = ({ unregistered, tenure }) => {
+  const freehold = tenure?.toLowerCase() === "freehold";
+
+  const registryUrl = freehold
+    ? "https://search-property-information.service.gov.uk/search/search-by-inspire-id"
+    : "https://search-property-information.service.gov.uk/search/search-by-title-number";
+
   return (
     <div className="property-details-info">
       <div className="property-details-info__small-print">
@@ -9,7 +15,7 @@ const PropertySectionSmallPrint = ({ unregistered }) => {
             You can access title register documents for a small fee by visiting
             the{" "}
             <a
-              href="https://search-property-information.service.gov.uk/search/search-by-inspire-id"
+              href={registryUrl}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/left-pane/property-section/property-section-small-print/PropertySectionSmallPrint.js
+++ b/src/components/left-pane/property-section/property-section-small-print/PropertySectionSmallPrint.js
@@ -1,8 +1,6 @@
 import React from "react";
 
-const PropertySectionSmallPrint = ({ unregistered, tenure }) => {
-  const freehold = tenure?.toLowerCase() === "freehold";
-
+const PropertySectionSmallPrint = ({ unregistered, freehold }) => {
   const registryUrl = freehold
     ? "https://search-property-information.service.gov.uk/search/search-by-inspire-id"
     : "https://search-property-information.service.gov.uk/search/search-by-title-number";


### PR DESCRIPTION
### What? Why?

Minor UI changes within the property display, some with caveats / questions appended to the bottom of the issue.

These changes include:
- Proprietor One name visible when property tab expanded
- Title number in property header selectable
- INSPIRE ID or HMLR Poly ID title displayed if property is freehold or leasehold
- Date Property added field change to Last Change

Relates to #365

### Detailed summary

**Property type awareness and dynamic labeling:**
- The code now detects if a property is freehold and uses this to adjust labels, such as displaying "INSPIRE ID" instead of "HMLR Poly ID" for freehold properties in `OverviewDetails`. [[1]](diffhunk://#diff-f95faa0425053c15a2761c65ffe1d1f0832f802b697142d530b0379cb6ccd8caR81) [[2]](diffhunk://#diff-89e9f32695bbf22670b7409db1cef82b9d4503c28b1e0233a523fadfdffd0db6L36-R37)
- The small print component (`PropertySectionSmallPrint`) now receives a `freehold` prop and updates the registry link to use the appropriate government service URL for freehold or other tenures. [[1]](diffhunk://#diff-f95faa0425053c15a2761c65ffe1d1f0832f802b697142d530b0379cb6ccd8caL123-R128) [[2]](diffhunk://#diff-2d12a13fc5fc342d1ecce30667a8e6323e18996f0b94c52e4fe2b5c3b30f255bL3-R7) [[3]](diffhunk://#diff-2d12a13fc5fc342d1ecce30667a8e6323e18996f0b94c52e4fe2b5c3b30f255bL12-R16)

**Ownership details enhancements:**
- The ownership details section now displays the date of the last change and the name of the first proprietor, with dynamic labeling if there is more than one proprietor. [[1]](diffhunk://#diff-2f3ff30ae585aecdd8f7fe288326b6cc859a1f1fec4ee9ae9e8d46122c5c42e3R7) [[2]](diffhunk://#diff-2f3ff30ae585aecdd8f7fe288326b6cc859a1f1fec4ee9ae9e8d46122c5c42e3R27-L30)

**UI/UX improvements:**
- The property section header number is now selectable text, improving usability for copying.

**Component interface updates:**
- Props for `freehold` are threaded through relevant components to enable the above dynamic behaviors. [[1]](diffhunk://#diff-f95faa0425053c15a2761c65ffe1d1f0832f802b697142d530b0379cb6ccd8caR112) [[2]](diffhunk://#diff-89e9f32695bbf22670b7409db1cef82b9d4503c28b1e0233a523fadfdffd0db6R9)

### What should we test?
- Turn on Landownership layer
- Select a property with ownership details
- Within the property panel check:
  - Property title number is selectable
  - The Proprietor name is visible and the placement is satisfactory
  - Last Change field is present and not Date Proprietor Added
- Select a freehold and leasehold property and check field heading switches between INSPIRE ID and HMLR Poly ID


