### PR TITLE
Update social housing layer disclaimer text

### DIFF
--- a/src/components/left-pane/LeftPaneLandData.js
+++ b/src/components/left-pane/LeftPaneLandData.js
@@ -165,7 +165,11 @@ const LeftPaneLandData = ({ open, active, onClose }) => {
           onToggle={() => dispatch(togglePropertyDisplay("socialHousing"))}
           disclaimer={true}
           disclaimerContent={
-            <>Social Housing provider data may not be accurate.</>
+            <>
+              This layer is based on registered social housing providers in
+              England and Wales. Note that local authorities can also provide
+              social housing, and these won't be included in the layer.
+            </>
           }
         />
         <LeftPaneToggle


### PR DESCRIPTION
#### What? Why?
Update to the disclaimer copy for the Social Housing layer in the `LeftPaneLandData` component to provide clearer information to the user.

Fixes #405 

- **User-facing content update:**
  - The disclaimer for the Social Housing provider layer now clarifies that the layer is based on registered providers in England and Wales and excludes local authority-provided social housing. (`src/components/left-pane/LeftPaneLandData.js`)

#### Code-specific details (for Reviewer)

- Check the text update in  `src/components/left-pane/LeftPaneLandData.js` is correct