### PR TITLE
Uri encode the proprietor name when calling search endpoint

### DIFF
--- a/src/actions/LandOwnershipActions.js
+++ b/src/actions/LandOwnershipActions.js
@@ -84,7 +84,9 @@ export const fetchRelatedProperties = (proprietorName) => {
     dispatch({ type: "FETCH_RELATED_PROPERTIES_LOADING" });
 
     const relatedPropertiesTitleMap = await dispatch(
-      getRequest(`/api/search?proprietorName=${proprietorName}`)
+      getRequest(
+        `/api/search?proprietorName=${encodeURIComponent(proprietorName)}`,
+      ),
     );
 
     if (relatedPropertiesTitleMap !== null) {


### PR DESCRIPTION
#### What? Why?

Fixes #417
The bug is caused because the frontend isn't URI encoding the proprietor name before calling the backend. This particular proprietor name (THE MAYOR & BURGESSES OF THE LONDON BOROUGH OF HARINGEY) contains an ampersand, which is used to separate query parameters. This means that when the backsearch is performed the proprietor name is cut off at the `&` i.e. it only searches for 'THE MAYOR' and therefore returns no properties.

#### Checklist (do these before sending for review)
- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [ ] Checked that all automated tests pass

#### What should we test? (for QA)
Follow the replication steps in the linked issue - the proprietor's properties should now be returned

#### Deployment notes
None
