### PR TITLE
Task/422 upgrade node version

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "🔧 setup node"
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '24.x'
           cache: 'yarn'
 
       - name: "📦 install dependencies"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a Digital Commons Cooperative project. Please follow our [contributor gu
 
 ## Requirements
 
-- Node 16
+- Node 24
 - Yarn 1.22
 
 ## Get Started


### PR DESCRIPTION
#### What? Why?

Fixes #422 

Upgrade to use node version 24 from 16

#### What should we test? (for QA)
Smoke test all functionality

#### Deployment notes
Upgrade node version on the server to v24.x 

Node on the server is managed by `nvm`. You can see the available versions of node using `nvm ls` and then you can switch to different version with `nvm use <version>`

So we need to do `nvm install 24.15.0` and then it's advised to do `nvm alias default 24.15.0` so that the default is also changed