### PR TITLE
389 analytics and opt in/out flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ VITE_OS_KEY=<get this from the Ordnance Survey dashboard>
 VITE_OS_PLACES_KEY=<get this from the Ordnance Survey dashboard>
 VITE_GEOCODER_TOKEN=<get this from the Mapbox dashboard>
 VITE_MAPBOX_TOKEN=<get this from the Mapbox dashboard>
+VITE_MIXPANEL_TOKEN=<get this from the Mixpanel dashboard>
+VITE_MIXPANEL_PEPPER=<random string - match this to the backend value>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "events": "^3.3.0",
     "lodash": "^4.18.1",
     "mapbox-gl": "^2.7.0",
+    "mixpanel-browser": "^2.79.0",
     "moment": "^2.29.1",
     "react": "^19.2.4",
     "react-device-detect": "^2.1.2",

--- a/src/actions/AuthenticationActions.ts
+++ b/src/actions/AuthenticationActions.ts
@@ -1,5 +1,8 @@
+import { optOutAndResetAnalyticsUser } from "@/analytics";
+
 export const logOut = () => {
   return async (dispatch: any) => {
+    optOutAndResetAnalyticsUser();
     dispatch({ type: "LOG_OUT" });
   };
 };

--- a/src/actions/AuthenticationActions.ts
+++ b/src/actions/AuthenticationActions.ts
@@ -6,3 +6,10 @@ export const logOut = () => {
     dispatch({ type: "LOG_OUT" });
   };
 };
+
+export const sessionTimedOut = () => {
+  return async (dispatch: any) => {
+    optOutAndResetAnalyticsUser();
+    dispatch({ type: "SESSION_TIMED_OUT" });
+  };
+};

--- a/src/actions/RequestActions.ts
+++ b/src/actions/RequestActions.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import constants from "../constants";
 import { getAuthHeader } from "../utils/Auth";
+import { RootState } from "@/store";
 
 /**
  * Make a GET request to the given API endpoint.
@@ -11,12 +12,15 @@ import { getAuthHeader } from "../utils/Auth";
  * @returns {Promise<any>} the resulting data, or null if the request failed
  */
 export const getRequest = (endpoint: string) => {
-  return async (dispatch: any) => {
+  return async (dispatch: any, getState: () => RootState) => {
     try {
-      const response = await axios.get(
-        `${constants.ROOT_URL}${endpoint}`,
-        getAuthHeader()
-      );
+      const { sessionId } = getState().user;
+      const response = await axios.get(`${constants.ROOT_URL}${endpoint}`, {
+        headers: {
+          ...getAuthHeader().headers,
+          "x-session-id": sessionId,
+        },
+      });
       return response.data;
     } catch (err: any) {
       console.error(`There was an error in ${endpoint} GET request`, err);
@@ -39,13 +43,15 @@ export const getRequest = (endpoint: string) => {
  * @returns {Promise<boolean>} whether the request was successful
  */
 export const postRequest = (endpoint: string, body: any) => {
-  return async (dispatch: any) => {
+  return async (dispatch: any, getState: () => RootState) => {
     try {
-      await axios.post(
-        `${constants.ROOT_URL}${endpoint}`,
-        body,
-        getAuthHeader()
-      );
+      const { sessionId } = getState().user;
+      await axios.post(`${constants.ROOT_URL}${endpoint}`, body, {
+        headers: {
+          ...getAuthHeader().headers,
+          "x-session-id": sessionId,
+        },
+      });
       return true;
     } catch (err: any) {
       console.error(`There was an error in ${endpoint} POST request`, err);

--- a/src/actions/RequestActions.ts
+++ b/src/actions/RequestActions.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import constants from "../constants";
 import { getAuthHeader } from "../utils/Auth";
 import { RootState } from "@/store";
+import { sessionTimedOut } from "./AuthenticationActions";
 
 /**
  * Make a GET request to the given API endpoint.
@@ -26,7 +27,7 @@ export const getRequest = (endpoint: string) => {
       console.error(`There was an error in ${endpoint} GET request`, err);
 
       if (err.response?.status === 401) {
-        dispatch({ type: "SESSION_TIMED_OUT" });
+        await dispatch(sessionTimedOut());
       }
     }
     return null;
@@ -57,7 +58,7 @@ export const postRequest = (endpoint: string, body: any) => {
       console.error(`There was an error in ${endpoint} POST request`, err);
 
       if (err.response?.status === 401) {
-        dispatch({ type: "SESSION_TIMED_OUT" });
+        await dispatch(sessionTimedOut());
       }
     }
     return false;

--- a/src/actions/UserActions.ts
+++ b/src/actions/UserActions.ts
@@ -1,4 +1,9 @@
+import { AppDispatch } from "@/store";
 import { getRequest, postRequest } from "./RequestActions";
+import {
+  optInAndSetAnalyticsUser,
+  optOutAndResetAnalyticsUser,
+} from "@/analytics";
 
 export const getUserDetails = () => {
   return async (dispatch: any) => {
@@ -25,7 +30,7 @@ export const getAskForFeedback = () => {
 export const setAskForFeedback = (status: boolean) => {
   return async (dispatch: any) => {
     const success = await dispatch(
-      postRequest("/api/user/ask-for-feedback", { askForFeedback: status })
+      postRequest("/api/user/ask-for-feedback", { askForFeedback: status }),
     );
 
     if (success) {
@@ -33,6 +38,31 @@ export const setAskForFeedback = (status: boolean) => {
         type: "USER_FEEDBACK_STATUS",
         payload: status,
       });
+    }
+  };
+};
+
+export const setAnalyticsConsent = (
+  status: boolean,
+  userId: string,
+  username: string,
+) => {
+  return async (dispatch: AppDispatch) => {
+    const success = await dispatch(
+      postRequest("/api/user/analytics-consent", { analyticsConsent: status }),
+    );
+
+    if (success) {
+      await dispatch({
+        type: "USER_ANALYTICS_CONSENT_STATUS",
+        payload: status,
+      });
+
+      if (status === true) {
+        await optInAndSetAnalyticsUser(userId, username);
+      } else {
+        await optOutAndResetAnalyticsUser();
+      }
     }
   };
 };

--- a/src/actions/UserActions.ts
+++ b/src/actions/UserActions.ts
@@ -11,7 +11,11 @@ export const getUserDetails = () => {
     if (userData) {
       dispatch({ type: "POPULATE_USER", payload: userData });
       if (userData.analyticsConsent === true) {
-        await optInAndSetAnalyticsUser(userData.id, userData.username);
+        try {
+          await optInAndSetAnalyticsUser(userData.id, userData.username);
+        } catch {
+          // analytics failure should not prevent the app from loading
+        }
       } else if (userData.analyticsConsent === false) {
         optOutAndResetAnalyticsUser();
       }
@@ -61,10 +65,16 @@ export const setAnalyticsConsent = (status: boolean) => {
 
       if (status) {
         const { id, username } = getState().user;
-        await optInAndSetAnalyticsUser(id, username);
+        try {
+          await optInAndSetAnalyticsUser(id, username);
+        } catch {
+          // analytics failure should not prevent consent from being saved
+        }
       } else {
         optOutAndResetAnalyticsUser();
       }
     }
+
+    return success;
   };
 };

--- a/src/actions/UserActions.ts
+++ b/src/actions/UserActions.ts
@@ -1,4 +1,4 @@
-import { AppDispatch } from "@/store";
+import { AppDispatch, RootState } from "@/store";
 import { getRequest, postRequest } from "./RequestActions";
 import {
   optInAndSetAnalyticsUser,
@@ -10,6 +10,11 @@ export const getUserDetails = () => {
     const userData = await dispatch(getRequest("/api/user/details"));
     if (userData) {
       dispatch({ type: "POPULATE_USER", payload: userData });
+      if (userData.analyticsConsent === true) {
+        await optInAndSetAnalyticsUser(userData.id, userData.username);
+      } else if (userData.analyticsConsent === false) {
+        optOutAndResetAnalyticsUser();
+      }
     }
   };
 };
@@ -42,26 +47,23 @@ export const setAskForFeedback = (status: boolean) => {
   };
 };
 
-export const setAnalyticsConsent = (
-  status: boolean,
-  userId: string,
-  username: string,
-) => {
-  return async (dispatch: AppDispatch) => {
+export const setAnalyticsConsent = (status: boolean) => {
+  return async (dispatch: AppDispatch, getState: () => RootState) => {
     const success = await dispatch(
       postRequest("/api/user/analytics-consent", { analyticsConsent: status }),
     );
 
     if (success) {
-      await dispatch({
+      dispatch({
         type: "USER_ANALYTICS_CONSENT_STATUS",
         payload: status,
       });
 
-      if (status === true) {
-        await optInAndSetAnalyticsUser(userId, username);
+      if (status) {
+        const { id, username } = getState().user;
+        await optInAndSetAnalyticsUser(id, username);
       } else {
-        await optOutAndResetAnalyticsUser();
+        optOutAndResetAnalyticsUser();
       }
     }
   };

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,16 +1,9 @@
 import mixpanel from "mixpanel-browser";
 import constants from "@/constants";
 import { AnalyticsEvent } from "./types/analytics-events";
-import { User } from "./reducers/UserReducer";
-import store from "./store";
 
 const analyticsEnabled =
   !!constants.MIXPANEL_TOKEN && !!constants.MIXPANEL_PEPPER;
-
-const userConsentGiven = () => {
-  const user = store.getState().user as User;
-  return user.analyticsConsent === true;
-};
 
 export const initializeMixpanel = (): void => {
   if (!constants.MIXPANEL_TOKEN || !constants.MIXPANEL_PEPPER) {
@@ -30,12 +23,15 @@ export const optInAndSetAnalyticsUser = async (
   userId: string,
   username: string,
 ) => {
-  if (!analyticsEnabled || !userConsentGiven()) {
+  if (!analyticsEnabled) {
     return;
   }
-  mixpanel.opt_in_tracking();
+
   const user = await getUserHash(userId, username);
   mixpanel.identify(user);
+  if (!mixpanel.has_opted_in_tracking()) {
+    mixpanel.opt_in_tracking();
+  }
 };
 
 /** Reset the user in the Mixpanel event data e.g. when user logs out */
@@ -69,8 +65,9 @@ const getUserHash = async (userId: string, username: string) => {
 export const trackEvent = <T extends Record<string, unknown>>(
   action: AnalyticsEvent,
   data: T,
+  consent: boolean,
 ) => {
-  if (!analyticsEnabled || !userConsentGiven()) {
+  if (!analyticsEnabled || !consent) {
     return;
   }
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,56 +1,78 @@
-// Commented this out for now since we are currently only sending analytics from the back-end.
-// We can re-enable front-end analytics later if needed.
+import mixpanel from "mixpanel-browser";
+import constants from "@/constants";
+import { AnalyticsEvent } from "./types/analytics-events";
+import { User } from "./reducers/UserReducer";
+import store from "./store";
 
-// import mixpanel from "mixpanel-browser";
+const analyticsEnabled =
+  !!constants.MIXPANEL_TOKEN && !!constants.MIXPANEL_PEPPER;
 
-// mixpanel.init(process.env.MIXPANEL_TOKEN, {
-//   debug: true,
-//   persistence: "localStorage",
-// });
+const userConsentGiven = () => {
+  const user = store.getState().user as User;
+  return user.analyticsConsent === true;
+};
 
-// let userId = null;
-// let user = null;
+export const initializeMixpanel = (): void => {
+  if (!constants.MIXPANEL_TOKEN || !constants.MIXPANEL_PEPPER) {
+    return;
+  }
 
-// /** Set (anonymized) user in the Mixpanel event data */
-// export const setUser = async (id, username) => {
-//   console.log(`[ANALYTICS] setUser`);
-//   if (userId !== id) {
-//     // Only need to re-compute hash if the user ID has changed
-//     userId = id;
-//     user = await getUserHash(id, username);
-//   }
-//   mixpanel.identify(user);
-// };
+  mixpanel.init(constants.MIXPANEL_TOKEN, {
+    debug: constants.DEV_MODE || false,
+    persistence: "localStorage",
+    ip: false,
+    opt_out_tracking_by_default: true,
+  });
+};
 
-// /** Reset the user in the Mixpanel event data e.g. when user logs out */
-// export const resetUser = () => {
-//   console.log(`[ANALYTICS] resetUser`);
-//   mixpanel.reset();
-//   userId = null;
-//   user = "LOGGED_OUT";
-// };
+/** Set (anonymized) user in the Mixpanel event data */
+export const optInAndSetAnalyticsUser = async (
+  userId: string,
+  username: string,
+) => {
+  if (!analyticsEnabled || !userConsentGiven()) {
+    return;
+  }
+  mixpanel.opt_in_tracking();
+  const user = await getUserHash(userId, username);
+  mixpanel.identify(user);
+};
 
-// /**
-//  * Convert a userId to a hashed value, using their username as a salt, to anonymize it for
-//  * analytics. This must match with the back-end's implementation, so analytics can be correlated.
-//  */
-// const getUserHash = async (id, username) => {
-//   const saltedInput = `${username}${id}`;
+/** Reset the user in the Mixpanel event data e.g. when user logs out */
+export const optOutAndResetAnalyticsUser = () => {
+  if (!analyticsEnabled) {
+    return;
+  }
+  mixpanel.opt_out_tracking();
+  mixpanel.reset();
+};
 
-//   // Compute SHA-256 hash
-//   const encoder = new TextEncoder();
-//   const data = encoder.encode(saltedInput);
-//   const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+/**
+ * Convert a userId to a hashed value, using their username as a salt, to anonymize it for
+ * analytics. This must match with the back-end's implementation, so analytics can be correlated.
+ */
+const getUserHash = async (userId: string, username: string) => {
+  const saltAndPepperedInput = `${userId}${username}${constants.MIXPANEL_PEPPER}`;
 
-//   // Convert buffer to hex string and return first 10 characters
-//   return Array.from(new Uint8Array(hashBuffer))
-//     .map((byte) => byte.toString(16).padStart(2, "0"))
-//     .join("")
-//     .substring(0, 10);
-// };
+  // Compute SHA-256 hash
+  const encoder = new TextEncoder();
+  const data = encoder.encode(saltAndPepperedInput);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
 
-// export const trackEvent = (category, action, data) => {
-//   const event = `${category}_${action}`;
-//   console.log(`[ANALYTICS] ${event}`);
-//   mixpanel.track(event, data);
-// };
+  // Convert buffer to hex string and return first 16 characters
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .substring(0, 16);
+};
+
+export const trackEvent = <T extends Record<string, unknown>>(
+  action: AnalyticsEvent,
+  data: T,
+) => {
+  if (!analyticsEnabled || !userConsentGiven()) {
+    return;
+  }
+
+  mixpanel.track(action, data);
+};

--- a/src/assets/styles/_buttons.scss
+++ b/src/assets/styles/_buttons.scss
@@ -83,6 +83,31 @@
   background-repeat: no-repeat;
 }
 
+.rounded-button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 6px 16px;
+  background: $buttonGreen;
+  border-radius: 100px;  
+  border: none;
+  color: #ffffff;
+  font-family: Lato;
+  font-size: 16px;
+  line-height: 1.2;
+  text-align: center;
+  cursor: pointer;
+  box-sizing: border-box;
+  user-select: none;
+
+  &:hover {
+    background: $primaryColor;
+    box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.25);
+  }
+}
+
 .rounded-button-full {
   border-radius: 100px;
   padding: 6px 18px;
@@ -174,6 +199,11 @@
       color: $primaryColor;
     }
   }
+}
+
+.rounded-button-outline-lg {
+  @extend .rounded-button-outline; 
+  font-size: 16px;
 }
 
 #controls {

--- a/src/assets/styles/_consent-banner.scss
+++ b/src/assets/styles/_consent-banner.scss
@@ -12,8 +12,8 @@
 .consent-banner {
   position: fixed;
   bottom: 40px;
-  left: 40%;
-  transform: translateX(-40%);
+  left: 50%;
+  transform: translateX(-50%);
   background-color: #EFF0F2;
   padding: 30px 50px;
   gap: 48px;
@@ -37,6 +37,8 @@
   display: flex;
   gap: 16px;
   align-items: flex-start;
+  margin: 0;
+  line-height: 27px;
 }
 
 .consent-banner__copy-icon {
@@ -56,11 +58,6 @@
   gap: 8px;
   align-items: center;
   font-size: 20px;
-}
-
-.consent-banner__copy {
-  margin: 0;
-  line-height: 27px;
 }
 
 .consent-banner__copy-footer {

--- a/src/assets/styles/_consent-banner.scss
+++ b/src/assets/styles/_consent-banner.scss
@@ -1,0 +1,75 @@
+.consent-banner-container {
+   position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 100008;
+  transition: opacity 0.4s;
+}
+
+.consent-banner {
+  position: fixed;
+  bottom: 40px;
+  left: 40%;
+  transform: translateX(-40%);
+  background-color: #EFF0F2;
+  padding: 30px 50px;
+  gap: 48px;
+  box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.16);
+  border-left: 5px solid $primaryColor;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 999999;
+  border-radius: 4px;
+}
+
+.consent-banner__copy-container {
+  display: flex;
+  flex-direction: column;
+  font-size: 16px;
+}
+
+.consent-banner__copy {
+  font-size: 16px;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.consent-banner__copy-icon {
+  font-size: 20px;
+  color: $primaryColor;
+  padding-top: 5px;
+}
+
+.consent-banner__copy-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.consent-banner__copy-title {
+  color: $primaryColor;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 20px;
+}
+
+.consent-banner__copy {
+  margin: 0;
+  line-height: 27px;
+}
+
+.consent-banner__copy-footer {
+  font-size: 12px;
+}
+
+.consent-banner__buttons {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  gap: 12px;
+}

--- a/src/assets/styles/_privacy-settings.scss
+++ b/src/assets/styles/_privacy-settings.scss
@@ -42,7 +42,13 @@
   justify-content: center;
 }
 
+.privacy-settings__copy {
+  font-size: 14px;
+  line-height: 1.5;
+  color: $secondaryColor;
+}
+
 .privacy-settings__copy-footer {
-  font-size: 14px;  
-  color: $secondaryColor;  
+  font-size: 12px;
+  color: $secondaryColor;
 }

--- a/src/assets/styles/_privacy-settings.scss
+++ b/src/assets/styles/_privacy-settings.scss
@@ -1,0 +1,52 @@
+.privacy-settings__container {
+  width: 340px;
+  top: 6rem;
+  max-width: "90vw";
+  height: "auto";
+  top: 6rem;
+  position: relative;
+  padding: 1rem;
+  margin: 0 auto;
+  box-sizing: border-box;
+  padding: 6px 24px 12px 24px;
+  border-radius: 8px;
+  background: "white";
+  padding: 1rem;
+  margin: 0 auto;
+}
+
+.privacy-settings {
+  display: flex;
+  flex-direction: column; 
+  gap: 12px; 
+  font-size: 16px;
+}
+
+.privacy-settings__title {
+  font-weight: 600;
+  display: flex;
+  justify-content: center;
+}
+
+.privacy-settings__toggle-group {
+  display: flex;
+  align-items: center;  
+  cursor: pointer;
+  padding-bottom: 1rem;
+  gap: 1rem;
+}
+
+.privacy-settings__toggle-label {   
+  color: $secondaryColor;
+  padding-right: 1rem; 
+}
+
+.privacy-settings__button-group {
+  display: flex;
+  justify-content: center;
+}
+
+.privacy-settings__copy-footer {
+  font-size: 14px;  
+  color: $secondaryColor;  
+}

--- a/src/assets/styles/_privacy-settings.scss
+++ b/src/assets/styles/_privacy-settings.scss
@@ -43,7 +43,7 @@
 }
 
 .privacy-settings__copy {
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.5;
   color: $secondaryColor;
 }

--- a/src/assets/styles/_privacy-settings.scss
+++ b/src/assets/styles/_privacy-settings.scss
@@ -1,18 +1,14 @@
 .privacy-settings__container {
   width: 340px;
   top: 6rem;
-  max-width: "90vw";
-  height: "auto";
-  top: 6rem;
-  position: relative;
-  padding: 1rem;
+  max-width: 90vw;
+  height: auto;  
+  position: relative;  
   margin: 0 auto;
-  box-sizing: border-box;
-  padding: 6px 24px 12px 24px;
+  box-sizing: border-box;  
   border-radius: 8px;
-  background: "white";
-  padding: 1rem;
-  margin: 0 auto;
+  background: white;
+  padding: 1rem;  
 }
 
 .privacy-settings {

--- a/src/assets/styles/style.scss
+++ b/src/assets/styles/style.scss
@@ -25,7 +25,7 @@
 @import "notifications";
 @import "search";
 @import "consent-banner";
-
+@import "privacy-settings";
 :root {
   --data-group-colour: #27ae60;
 }

--- a/src/assets/styles/style.scss
+++ b/src/assets/styles/style.scss
@@ -24,6 +24,8 @@
 @import "map-being-edited";
 @import "notifications";
 @import "search";
+@import "consent-banner";
+
 :root {
   --data-group-colour: #27ae60;
 }

--- a/src/components/map/ConsentBanner.tsx
+++ b/src/components/map/ConsentBanner.tsx
@@ -1,0 +1,63 @@
+import { setAnalyticsConsent } from "@/actions/UserActions";
+import { useAppDispatch, useAppSelector } from "@/hooks/react-redux";
+import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const ConsentBanner = () => {
+  const dispatch = useAppDispatch();
+  const { id: userId, username, analyticsConsent } = useAppSelector((state) => state.user);
+  
+  const handleAllowAnalytics = async () => {
+    await dispatch(setAnalyticsConsent(true, userId, username));
+  };
+
+  const handleDenyAnalytics = async () => {
+    await dispatch(setAnalyticsConsent(false, userId, username));
+  };
+  
+  if (analyticsConsent !== null) {
+      return null;
+  }
+  return (    
+    <div id="consent-banner-container" className="consent-banner-container">
+      <div id="analytics-consent-banner" className="consent-banner">
+        <div className="consent-banner__copy-container">
+          <div className="consent-banner__copy">
+            <FontAwesomeIcon
+              className="consent-banner__copy-icon"
+              icon={faCircleInfo}
+            />
+            <div className="consent-banner__copy-text">
+              <div className="consent-banner__copy-title">
+                Help improve Land Explorer
+              </div>
+              <p className="consent-banner__copy">
+                We use pseudonymous* analytics to understand how people use Land
+                Explorer and improve the service. You can turn this off at any
+                time in Privacy settings.
+              </p>
+              <p className="consent-banner__copy-footer">
+                 *This means analytics data may be
+                linked to an identifier, but not to your real name.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="consent-banner__buttons">
+          <button className="rounded-button" onClick={handleAllowAnalytics}>
+            Allow analytics
+          </button>
+          <button
+            className="rounded-button-outline-lg"
+            onClick={handleDenyAnalytics}
+          >
+            Turn off analytics
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+  
+};
+
+export default ConsentBanner;

--- a/src/components/map/ConsentBanner.tsx
+++ b/src/components/map/ConsentBanner.tsx
@@ -5,20 +5,16 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const ConsentBanner = () => {
   const dispatch = useAppDispatch();
-  const { id: userId, username, analyticsConsent } = useAppSelector((state) => state.user);
+  const { analyticsConsent } = useAppSelector((state) => state.user);
   
-  const handleAllowAnalytics = async () => {
-    await dispatch(setAnalyticsConsent(true, userId, username));
-  };
-
-  const handleDenyAnalytics = async () => {
-    await dispatch(setAnalyticsConsent(false, userId, username));
+  const handleAnalyticsConsentSet = async (value: boolean) => {
+    await dispatch(setAnalyticsConsent(value));
   };
   
-  if (analyticsConsent !== null) {
-      return null;
+  if (analyticsConsent !== null && analyticsConsent !== undefined) {
+    return null;
   }
-  return (    
+  return (
     <div id="consent-banner-container" className="consent-banner-container">
       <div id="analytics-consent-banner" className="consent-banner">
         <div className="consent-banner__copy-container">
@@ -37,19 +33,22 @@ const ConsentBanner = () => {
                 time in Privacy settings.
               </p>
               <p className="consent-banner__copy-footer">
-                 *This means analytics data may be
-                linked to an identifier, but not to your real name.
+                *This means analytics data may be linked to an identifier, but
+                not to your real name.
               </p>
             </div>
           </div>
         </div>
         <div className="consent-banner__buttons">
-          <button className="rounded-button" onClick={handleAllowAnalytics}>
+          <button
+            className="rounded-button"
+            onClick={() => handleAnalyticsConsentSet(true)}
+          >
             Allow analytics
           </button>
           <button
             className="rounded-button-outline-lg"
-            onClick={handleDenyAnalytics}
+            onClick={() => handleAnalyticsConsentSet(false)}
           >
             Turn off analytics
           </button>

--- a/src/components/map/MapboxMap.tsx
+++ b/src/components/map/MapboxMap.tsx
@@ -30,6 +30,7 @@ import FeedbackTab from "../common/FeedbackTab";
 import MapBeingEditedToast from "./MapBeingEditedToast";
 import BaseLayerMenu from "../map-controls/BaseLayerMenu";
 import MapLayerKey from "../map-controls/MapLayerKey";
+import ConsentBanner from "./ConsentBanner";
 
 // Set access token globally so all mapbox-gl instances share it
 mapboxgl.accessToken = constants.MAPBOX_TOKEN ?? "";
@@ -291,8 +292,8 @@ const MapboxMap = () => {
             baseLayer === "aerial"
               ? "#091324"
               : constants.USE_OS_TILES
-              ? "#aadeef"
-              : "#72b6e6",
+                ? "#aadeef"
+                : "#72b6e6",
         }}
         zoom={zoom}
         onZoomStart={() => dispatch(setZooming(true))}
@@ -389,6 +390,7 @@ const MapboxMap = () => {
       <FeedbackTab />
       <MapBeingEditedToast />
       <Modals />
+      <ConsentBanner />
       <div className="os-accreditation">
         Contains OS data © Crown copyright and database rights 2022 OS
         0100059691

--- a/src/components/top-bar/ProfileMenu.tsx
+++ b/src/components/top-bar/ProfileMenu.tsx
@@ -1,6 +1,7 @@
 import { useAppDispatch, useAppSelector } from "@/hooks/react-redux";
 import { Link } from "react-router-dom";
 import { openModal } from "../../actions/ModalActions";
+import { logOut } from "@/actions/AuthenticationActions";
 
 const ProfileMenu = () => {
   const dispatch = useAppDispatch();
@@ -30,8 +31,8 @@ const ProfileMenu = () => {
         </div>
         <div
           className="tooltip-menu-item"
-          onClick={() => {
-            dispatch({ type: "LOG_OUT" });
+          onClick={async () => {
+            await dispatch(logOut());
             closeProfileMen();
           }}
         >

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,8 @@ type Constants = {
   MAP_ACCESS_READ_WRITE: number;
   DATAGROUP_ACCESS_READ_ONLY: number;
   DATAGROUP_ACCESS_READ_WRITE: number;
+  MIXPANEL_TOKEN: string | undefined;
+  MIXPANEL_PEPPER: string | undefined;
 };
 
 const constants: Constants = {
@@ -74,6 +76,8 @@ const constants: Constants = {
   MAP_ACCESS_READ_WRITE: 3,
   DATAGROUP_ACCESS_READ_ONLY: 1,
   DATAGROUP_ACCESS_READ_WRITE: 3,
+  MIXPANEL_TOKEN: import.meta.env.VITE_MIXPANEL_TOKEN,
+  MIXPANEL_PEPPER: import.meta.env.VITE_MIXPANEL_PEPPER,
 };
 
 export const VERSION = "1.1";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,10 +9,13 @@ import Authentication from "./pages/Authentication";
 import ErrorFallback from "./pages/ErrorFallback";
 import { ErrorBoundary } from "react-error-boundary";
 import store from "./store";
+import { initializeMixpanel } from "./analytics";
 
 // Styles
 import "./index.css";
 import "./assets/styles/style.scss";
+
+initializeMixpanel();
 
 createRoot(document.getElementById("root")!).render(
   <Provider store={store}>

--- a/src/pages/MapApp.tsx
+++ b/src/pages/MapApp.tsx
@@ -14,10 +14,7 @@ import {
   establishSocketConnection,
   closeSocketConnection,
 } from "../actions/WebSocketActions";
-import {
-  optOutAndResetAnalyticsUser,
-  optInAndSetAnalyticsUser,
-} from "@/analytics";
+
 
 const MapApp = () => {
   const authenticated = useAppSelector(
@@ -45,9 +42,8 @@ const MapApp = () => {
           await dispatch(openMap(storedMapId));
         }
       } else {
-        // If not authenticated, remove token, disconnect websocket, reset analytics user, and redirect
+        // If not authenticated, remove token, disconnect websocket, and redirect
         // to login page
-        optOutAndResetAnalyticsUser();
         Auth.removeToken();
         dispatch(closeSocketConnection());
         sessionStorage.removeItem("currentMapId");
@@ -57,12 +53,6 @@ const MapApp = () => {
     })();
   }, [authenticated]);
 
-
-  useEffect(() => {
-    if (user.populated && user.analyticsConsent === true) {
-      optInAndSetAnalyticsUser(user.id, user.username);
-    }
-  }, [user.populated, user.analyticsConsent]);
 
   // If user details have been populated, render map, else render loading spinner
   if (user.populated) {

--- a/src/pages/MapApp.tsx
+++ b/src/pages/MapApp.tsx
@@ -14,6 +14,10 @@ import {
   establishSocketConnection,
   closeSocketConnection,
 } from "../actions/WebSocketActions";
+import {
+  optOutAndResetAnalyticsUser,
+  optInAndSetAnalyticsUser,
+} from "@/analytics";
 
 const MapApp = () => {
   const authenticated = useAppSelector(
@@ -29,9 +33,9 @@ const MapApp = () => {
       if (authenticated && Auth.isTokenActive()) {
         // If authenticated, get user details, setup websocket connection, and get maps
         await dispatch(getUserDetails());
-        dispatch(establishSocketConnection() as any);
-        dispatch(getAskForFeedback() as any);
-        await dispatch(getMyMaps() as any);
+        dispatch(establishSocketConnection());
+        dispatch(getAskForFeedback());
+        await dispatch(getMyMaps());
 
         // Open the map that was previously open if the page was refreshed
         const storedMapId = parseInt(
@@ -43,6 +47,7 @@ const MapApp = () => {
       } else {
         // If not authenticated, remove token, disconnect websocket, reset analytics user, and redirect
         // to login page
+        optOutAndResetAnalyticsUser();
         Auth.removeToken();
         dispatch(closeSocketConnection());
         sessionStorage.removeItem("currentMapId");
@@ -51,6 +56,13 @@ const MapApp = () => {
       }
     })();
   }, [authenticated]);
+
+
+  useEffect(() => {
+    if (user.populated && user.analyticsConsent === true) {
+      optInAndSetAnalyticsUser(user.id, user.username);
+    }
+  }, [user.populated, user.analyticsConsent]);
 
   // If user details have been populated, render map, else render loading spinner
   if (user.populated) {

--- a/src/pages/MyAccount.tsx
+++ b/src/pages/MyAccount.tsx
@@ -10,6 +10,9 @@ import ChangePassword from "./ChangePassword";
 import iconDetails from "../assets/img/icon-details.svg";
 import iconMail from "../assets/img/icon-mail.svg";
 import iconLock from "../assets/img/icon-lock.svg";
+import PrivacySettings from "@/pages/PrivacySettings";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faShieldHalved } from "@fortawesome/free-solid-svg-icons";
 
 type AccountViewProps = { initials: string };
 
@@ -94,6 +97,18 @@ const AccountView = ({ initials }: AccountViewProps) => {
             Edit
           </Link>
         </div>
+        <div className="my-account--option">
+          <div
+            className="my-account--option--left"
+            style={{ display: "flex", gap: "14px" }}
+          >
+            <FontAwesomeIcon icon={faShieldHalved} />
+            Privacy Settings
+          </div>
+          <Link to="/app/my-account/privacy" className="button button-small">
+            Edit
+          </Link>
+        </div>
       </div>
     </div>
   );
@@ -127,6 +142,7 @@ const MyAccount = () => {
           <Route path="/details" element={<ChangeDetails />} />
           <Route path="/email" element={<ChangeEmail />} />
           <Route path="/password" element={<ChangePassword />} />
+          <Route path="/privacy" element={<PrivacySettings />} />
         </Routes>
       </div>
     </div>

--- a/src/pages/PrivacySettings.tsx
+++ b/src/pages/PrivacySettings.tsx
@@ -25,10 +25,17 @@ const PrivacySettings = () => {
       Swal.fire({
         icon: "error",
         text: "Failed to save privacy settings. Please try again.",
+        toast: true,
+        timer: 3000,
+        position: "top",
+        didOpen: (popup) => {
+          const container = popup.parentElement;
+          if (container) container.style.zIndex = "100010";
+        },
       });
-      return;
+    } else {
+      navigator("/app/my-account");
     }
-    navigator("/app/my-account");
   };
 
   return (

--- a/src/pages/PrivacySettings.tsx
+++ b/src/pages/PrivacySettings.tsx
@@ -7,11 +7,7 @@ import { Link, useNavigate } from "react-router-dom";
 const PrivacySettings = () => {
   const dispatch = useAppDispatch();
   const navigator = useNavigate();
-  const {
-    id: userId,
-    username,
-    analyticsConsent,
-  } = useAppSelector((state) => state.user);
+  const { analyticsConsent } = useAppSelector((state) => state.user);
 
   const [currentAnalyticsConsent, setCurrentAnalyticsConsent] = useState(
     analyticsConsent ?? false,
@@ -22,9 +18,7 @@ const PrivacySettings = () => {
   };
 
   const savePrivacySettings = async () => {
-    await dispatch(
-      setAnalyticsConsent(currentAnalyticsConsent, userId, username),
-    );
+    await dispatch(setAnalyticsConsent(currentAnalyticsConsent));
     navigator("/app/my-account");
   };
 

--- a/src/pages/PrivacySettings.tsx
+++ b/src/pages/PrivacySettings.tsx
@@ -1,0 +1,64 @@
+import { setAnalyticsConsent } from "@/actions/UserActions";
+import ToggleSwitch from "@/components/common/ToggleSwitch";
+import { useAppDispatch, useAppSelector } from "@/hooks/react-redux";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+const PrivacySettings = () => {
+  const dispatch = useAppDispatch();
+  const navigator = useNavigate();
+  const {
+    id: userId,
+    username,
+    analyticsConsent,
+  } = useAppSelector((state) => state.user);
+
+  const [currentAnalyticsConsent, setCurrentAnalyticsConsent] = useState(
+    analyticsConsent ?? false,
+  );
+
+  const toggleAnalyticsConsent = async () => {
+    setCurrentAnalyticsConsent(!currentAnalyticsConsent);
+  };
+
+  const savePrivacySettings = async () => {
+    await dispatch(
+      setAnalyticsConsent(currentAnalyticsConsent, userId, username),
+    );
+    navigator("/app/my-account");
+  };
+
+  return (
+    <div className="privacy-settings__container modal">
+      <div className="privacy-settings">
+        <h3 className="privacy-settings__title">Privacy Settings</h3>
+        {<Link to="/app/my-account" className="modal-close" />}
+        <p className="privacy-settings__copy">
+          {" "}
+          We use pseudonymous* analytics to understand how people use Land
+          Explorer and improve the service.
+          <br />
+          <br />
+          You can turn this on/off at any time using the toggle below.
+        </p>
+        <div className="privacy-settings__toggle-group">
+          <ToggleSwitch
+            on={currentAnalyticsConsent === true}
+            tooltip="Enable or disable analytics tracking"
+            toggle={toggleAnalyticsConsent}
+          />
+          <span>Allow Analytics</span>
+        </div>
+        <button className="rounded-button" onClick={savePrivacySettings}>
+          Save Changes
+        </button>
+        <p className="privacy-settings__copy-footer">
+          *This means analytics data may be linked to an identifier, but not to
+          your real name.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default PrivacySettings;

--- a/src/pages/PrivacySettings.tsx
+++ b/src/pages/PrivacySettings.tsx
@@ -3,7 +3,7 @@ import ToggleSwitch from "@/components/common/ToggleSwitch";
 import { useAppDispatch, useAppSelector } from "@/hooks/react-redux";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-
+import Swal from "sweetalert2";
 const PrivacySettings = () => {
   const dispatch = useAppDispatch();
   const navigator = useNavigate();
@@ -18,7 +18,16 @@ const PrivacySettings = () => {
   };
 
   const savePrivacySettings = async () => {
-    await dispatch(setAnalyticsConsent(currentAnalyticsConsent));
+    const success = await dispatch(
+      setAnalyticsConsent(currentAnalyticsConsent),
+    );
+    if (!success) {
+      Swal.fire({
+        icon: "error",
+        text: "Failed to save privacy settings. Please try again.",
+      });
+      return;
+    }
     navigator("/app/my-account");
   };
 

--- a/src/reducers/UserReducer.ts
+++ b/src/reducers/UserReducer.ts
@@ -1,6 +1,6 @@
 import { Action } from "../types";
 
-type User = {
+export type User = {
   id: string;
   initials: string;
   pic: string;
@@ -48,7 +48,7 @@ type UserPayload = {
   analyticsConsent: boolean | null;
 };
 
-const INITIAL_STATE: User = {
+const getInitialState = (): User => ({
   id: "",
   initials: "",
   pic: "",
@@ -73,7 +73,7 @@ const INITIAL_STATE: User = {
   askForFeedback: true,
   analyticsConsent: null,
   sessionId: crypto.randomUUID(),
-};
+});
 
 type UserAction =
   | (Action<UserPayload> & { type: "POPULATE_USER" })
@@ -81,7 +81,7 @@ type UserAction =
   | (Action<boolean> & { type: "USER_ANALYTICS_CONSENT_STATUS" })
   | Action;
 
-export default (state: User = INITIAL_STATE, action: UserAction): User => {
+export default (state: User = getInitialState(), action: UserAction): User => {
   switch (action.type) {
     case "POPULATE_USER": {
       const payload = action.payload as UserPayload;
@@ -93,6 +93,7 @@ export default (state: User = INITIAL_STATE, action: UserAction): User => {
         initials:
           payload.firstName[0].toUpperCase() +
           payload.lastName[0].toUpperCase(),
+        analyticsConsent: payload.analyticsConsent ?? null,
       };
     }
     case "USER_FEEDBACK_STATUS":

--- a/src/reducers/UserReducer.ts
+++ b/src/reducers/UserReducer.ts
@@ -23,6 +23,8 @@ type User = {
   populated: boolean;
   privileged: boolean;
   askForFeedback: boolean;
+  analyticsConsent: boolean | null;
+  sessionId: string;
 };
 
 type UserPayload = {
@@ -43,6 +45,7 @@ type UserPayload = {
   username?: string;
   pic?: string;
   is_super_user?: boolean;
+  analyticsConsent: boolean | null;
 };
 
 const INITIAL_STATE: User = {
@@ -68,11 +71,14 @@ const INITIAL_STATE: User = {
   populated: false,
   privileged: false,
   askForFeedback: true,
+  analyticsConsent: null,
+  sessionId: crypto.randomUUID(),
 };
 
 type UserAction =
-  | Action<UserPayload> & { type: "POPULATE_USER" }
-  | Action<boolean> & { type: "USER_FEEDBACK_STATUS" }
+  | (Action<UserPayload> & { type: "POPULATE_USER" })
+  | (Action<boolean> & { type: "USER_FEEDBACK_STATUS" })
+  | (Action<boolean> & { type: "USER_ANALYTICS_CONSENT_STATUS" })
   | Action;
 
 export default (state: User = INITIAL_STATE, action: UserAction): User => {
@@ -93,6 +99,11 @@ export default (state: User = INITIAL_STATE, action: UserAction): User => {
       return {
         ...state,
         askForFeedback: action.payload as boolean,
+      };
+    case "USER_ANALYTICS_CONSENT_STATUS":
+      return {
+        ...state,
+        analyticsConsent: action.payload as boolean,
       };
     default:
       return state;

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -48,7 +48,7 @@ type RootState = ReturnType<typeof appReducer>;
 
 const rootReducer = (state: RootState | undefined, action: Action): RootState => {
   // Clear all data in redux store to initial state when user logs out
-  if (action.type === "LOG_OUT") {
+  if (action.type === "LOG_OUT" || action.type === "SESSION_TIMED_OUT") {
     state = undefined;
   }
   return appReducer(state, action);

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,6 +5,7 @@ import rootReducer from "./reducers/rootReducer";
 import constants from "./constants";
 import { Action } from "./types";
 
+
 // Enable Redux DevTools if in dev mode
 console.log("dev mode: ", constants.DEV_MODE);
 

--- a/src/types/analytics-events.ts
+++ b/src/types/analytics-events.ts
@@ -1,0 +1,1 @@
+export type AnalyticsEvent = "";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -16,6 +16,8 @@ interface ImportMetaEnv {
   readonly VITE_OS_PLACES_KEY: string | undefined;
   readonly VITE_GEOCODER_TOKEN: string | undefined;
   readonly VITE_MAPBOX_TOKEN: string | undefined;
+  readonly VITE_MIXPANEL_TOKEN: string | undefined;
+  readonly VITE_MIXPANEL_PEPPER: string | undefined;
 }
 
 interface ImportMeta {

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,6 +704,49 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
+"@mixpanel/rrdom@^2.0.0-alpha.18":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrdom/-/rrdom-2.0.0-alpha.18.4.tgz#5229dc32d991d6a17870e5033558e9e2be9f1f3c"
+  integrity sha512-58sWLQDPRU0VQn8VzB1tx4ujih9X327Vr6xAzbJ4zge9GENm2L696T4TbWvrRGWPW6w99tHIHbv6SvcLhjjmcQ==
+  dependencies:
+    "@mixpanel/rrweb-snapshot" "^2.0.0-alpha.18"
+
+"@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.4":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.0.0-alpha.18.4.tgz#674c3d0292fed17ab57c9c5681d9f5669f9198ff"
+  integrity sha512-gGxEnNpfWurQht+fpSJbwPV60ug0LAENlk4Ux3XRmYooNJGPBO1TiQHcM7g0yhrKf4tfbTiKKZ4EXzFlOZs/pw==
+
+"@mixpanel/rrweb-snapshot@^2.0.0-alpha.18":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.4.tgz#80685f81f22b4a0aaa96625c164f738da2da1642"
+  integrity sha512-ubLGwgPiMMi0rl7zJRh1uMScQ480lT95tkHkIAHkiZOemMY4JSkYZh2v9fpMNwJhaGwB5n/76KI7Cwy8F5qixQ==
+  dependencies:
+    postcss "^8.4.38"
+
+"@mixpanel/rrweb-types@^2.0.0-alpha.18":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb-types/-/rrweb-types-2.0.0-alpha.18.4.tgz#9290688f03e434b26947f3d8f928cf8dadcc84e3"
+  integrity sha512-7kRuk7pK6Firrb26Mm235Po7s/z+9k0gUKZU/DZkzg5U1yQRcsu4byIrnWTiTQr+LFLUrIiyRKnpGK/QneAhTw==
+
+"@mixpanel/rrweb-utils@2.0.0-alpha.18.4", "@mixpanel/rrweb-utils@^2.0.0-alpha.18":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.4.tgz#ddf2faada57cd5d4b04894fcae87cfe3b61d919a"
+  integrity sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==
+
+"@mixpanel/rrweb@2.0.0-alpha.18.4":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.4.tgz#73a1403e0dc2ed2e35fd35a23ab8efd5c0f7239d"
+  integrity sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==
+  dependencies:
+    "@mixpanel/rrdom" "^2.0.0-alpha.18"
+    "@mixpanel/rrweb-snapshot" "^2.0.0-alpha.18"
+    "@mixpanel/rrweb-types" "^2.0.0-alpha.18"
+    "@mixpanel/rrweb-utils" "^2.0.0-alpha.18"
+    "@types/css-font-loading-module" "0.0.7"
+    "@xstate/fsm" "^1.4.0"
+    base64-arraybuffer "^1.0.1"
+    mitt "^3.0.0"
+
 "@redux-devtools/extension@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@redux-devtools/extension/-/extension-3.3.0.tgz#bc775d289f15604c472112920beac2cf4dbb7907"
@@ -2398,6 +2441,11 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
+"@types/css-font-loading-module@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz#2f98ede46acc0975de85c0b7b0ebe06041d24601"
+  integrity sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==
+
 "@types/d3-voronoi@^1.1.12":
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz#99d1bbf5438ac222727493bef2283da62ffc0aa3"
@@ -2429,6 +2477,11 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
+
+"@types/json-logic-js@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-logic-js/-/json-logic-js-2.0.5.tgz#8c2c8a42dc8cc21e2977f64dc7b944cf6479f782"
+  integrity sha512-hu/FTi0zwCjQEFfbPur275cNoZj6NsuOBhhYNzqoSdfmMhuxFr58OZ957lyIOWc9+kO+2tFlBthRjcxuytD4HA==
 
 "@types/kdbush@^1":
   version "1.0.7"
@@ -2556,6 +2609,11 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
 
+"@xstate/fsm@^1.4.0":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.5.tgz#f599e301997ad7e3c572a0b1ff0696898081bea5"
+  integrity sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -2608,6 +2666,11 @@ base-64@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==
+
+base64-arraybuffer@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
 bignumber.js@^9.1.0:
   version "9.3.1"
@@ -3433,6 +3496,11 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-logic-js@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/json-logic-js/-/json-logic-js-2.0.5.tgz#55f0c687dd6f56b02ccdcfdd64171ed998ab5499"
+  integrity sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==
+
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -3775,6 +3843,22 @@ minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+mitt@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
+mixpanel-browser@^2.79.0:
+  version "2.80.0"
+  resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.80.0.tgz#020d9dc263ea19107482e77930a9085f1ff8970f"
+  integrity sha512-kzhUk5dopABfF7rkKGHofR3fxPIK/OIDLqtwGyPN3PUTVUCNZqMY+gyionhMqjiOpL4ipXecT9YfF4siEre0GA==
+  dependencies:
+    "@mixpanel/rrweb" "2.0.0-alpha.18.4"
+    "@mixpanel/rrweb-plugin-console-record" "2.0.0-alpha.18.4"
+    "@mixpanel/rrweb-utils" "2.0.0-alpha.18.4"
+    "@types/json-logic-js" "2.0.5"
+    json-logic-js "2.0.5"
+
 moment@^2.29.1:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
@@ -3975,7 +4059,7 @@ polyclip-ts@^0.16.8:
     bignumber.js "^9.1.0"
     splaytree-ts "^1.0.2"
 
-postcss@^8.5.3:
+postcss@^8.4.38, postcss@^8.5.3:
   version "8.5.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==


### PR DESCRIPTION
#### What? Why?

Fixes DigitalCommons/land-explorer#29 

This adds frontend analytics and adds the analytics opt in/out flow. This is as follows:
- When a user logs in, if they haven't previously allowed/disallowed they will be shown a consent banner. 
- Their response is stored in the DB and they won't be shown the banner again. 
- There is a new setting under My account > privacy settings for them to change their analytics consent at a later point.
  - If the user allows analytics - we turn on both frontend and backend analytics. We use a pseudonymous hashing method for the userId in analytics so we can track patterns across sessions, but who the user is stays well hidden.
  - If the user says no to analytics - we turn off frontend analytics completely and use a random Id for the backend analytics so that it is fully anonymous. It stays the same for that session but changes between sessions, so we lose the cross-session tracking in that case.

#### What should we test? (for QA)
- On login, each user should see a consent banner (this will show for all users who haven't yet answered the consent question)
- Once the consent banner has been answered, subsequent logins or refreshes shouldn't show the consent banner.
- Check the privacy settings page works as expected
- Check that the backend analytics works as expected (there are no FE analytics implemented yet)
- Check that switching the analytics consent on/off does follow the rules set out above.

#### Deployment notes
Add to .env

```
VITE_MIXPANEL_TOKEN=<get this from the Mixpanel dashboard>
VITE_MIXPANEL_PEPPER=<random string - match this to the corresponding backend value>
```